### PR TITLE
Remove code repetition and improve readability of compiler tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,7 +66,8 @@
     "value.h": "c",
     "colors.h": "c",
     "hash_table.h": "c",
-    "vm.h": "c"
+    "vm.h": "c",
+    "typeinfo": "c"
   },
   "C_Cpp.errorSquiggles": "enabled"
 }


### PR DESCRIPTION
### Summary
Remove code repetition and improve readability of compiler tests.

Also fixes the "duplicated val" tests, which was crashing the program before due to val redeclaration.