### PR TITLE
Add support for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ The following features are necessary a proper v1.0 release, in rough order:
  - [X] Implement print statements
  - [X] Implement additive expression
  - [X] Implement all other "simple" expressions, i.e. excluding call-expressions
- - [ ] Implement string literals
+ - [X] Implement string literals
  - [ ] Implement selection statement (`if`s)
  - [ ] Implement the rest of the parser for the whole syntax grammar
  - [ ] Add conditional debugging/logging for tests that fail

--- a/code.sol
+++ b/code.sol
@@ -1,2 +1,2 @@
 // Example code
-print false || 0;
+val d = "a";

--- a/src/bytecode.h
+++ b/src/bytecode.h
@@ -65,7 +65,8 @@ typedef struct {
 
 typedef enum {
     CONST_TYPE_STRING,
-    CONST_TYPE_DOUBLE  // TODO: stop putting doubles in constant pool; inline it in the bytecode
+    CONST_TYPE_IDENTIFIER,  // identifiers are similar to strings, but handled slightly different
+    CONST_TYPE_DOUBLE       // TODO: stop putting doubles in constant pool; inline it in the bytecode
 } ConstantType;
 
 typedef struct {
@@ -80,6 +81,12 @@ typedef struct {
     (Constant) {                                   \
         .type = CONST_TYPE_STRING,                 \
         .as = {.string = nullTerminatedStringArg}, \
+    }
+
+#define IDENTIFIER_CONST(nullTerminatedIdentifierArg)  \
+    (Constant) {                                       \
+        .type = CONST_TYPE_IDENTIFIER,                 \
+        .as = {.string = nullTerminatedIdentifierArg}, \
     }
 
 #define DOUBLE_CONST(numberArg)      \

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -76,6 +76,7 @@ static size_t findConstantInPool(Compiler* compiler, Constant constant) {
         // Check if value is the same
         switch (compiler->constantPool.values[i].type) {
             case CONST_TYPE_STRING:
+            case CONST_TYPE_IDENTIFIER:
                 if (strcmp(constant.as.string, compiler->constantPool.values[i].as.string) == 0) return i;
                 break;
 
@@ -212,8 +213,8 @@ static void visitExpressionStatement(Compiler* compiler, ExpressionStatement* ex
 static void visitValDeclarationStatement(Compiler* compiler, ValDeclarationStatement* valDeclarationStatement) {
     visitExpression(compiler, valDeclarationStatement->expression);
 
-    Constant constant = STRING_CONST(copyStringToHeap(valDeclarationStatement->identifier->token.start,
-                                                      valDeclarationStatement->identifier->token.length));
+    Constant constant = IDENTIFIER_CONST(copyStringToHeap(valDeclarationStatement->identifier->token.start,
+                                                          valDeclarationStatement->identifier->token.length));
 
     // TODO: Remove duplicated check; addConstantToPool already runs findConstantInPool.
     if (findConstantInPool(compiler, constant) != -1) errorAndExit("Error: val \"%s\" is already declared. Redeclaration is not permitted.", constant.as.string);

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -257,7 +257,7 @@ static void visitIdentifierLiteral(Compiler* compiler, IdentifierLiteral* identi
     // Find address of this identifier in the constant pool
     char* identifierNameNullTerminated = strndup(identifierLiteral->token.start, identifierLiteral->token.length);
     Constant constant = (Constant){
-        .type = CONST_TYPE_STRING,
+        .type = CONST_TYPE_IDENTIFIER,
         .as = {identifierNameNullTerminated}};
     size_t index = findConstantInPool(compiler, constant);
     if (index == -1) errorAndExit("Error: identifier '%s' referenced before declaration.", identifierNameNullTerminated);

--- a/src/debug.c
+++ b/src/debug.c
@@ -242,7 +242,7 @@ static void printLiteral(const Literal* literal, int depth) {
             break;
 
         case STRING_LITERAL:
-            printf("StringLiteral" KGRY "(token=\"%.*s\")\n" RESET, literal->as.stringLiteral->token.length, literal->as.stringLiteral->token.start);
+            printf("StringLiteral" KGRY "(token=%.*s)\n" RESET, literal->as.stringLiteral->token.length, literal->as.stringLiteral->token.start);
             break;
 
             // Add cases for other literal types

--- a/src/debug.c
+++ b/src/debug.c
@@ -263,8 +263,10 @@ static void printConstantPool(ConstantPool constantPool) {
                 printf("(double) %f\n", value.as.number);
                 break;
             case CONST_TYPE_STRING:
-                // Assuming a function to get string from string pool: getStringFromPool(index)
                 printf("(string) \"%s\"\n", value.as.string);
+                break;
+            case CONST_TYPE_IDENTIFIER:
+                printf("(identifier) \"%s\"\n", value.as.string);
                 break;
         }
     }

--- a/src/parser.c
+++ b/src/parser.c
@@ -87,12 +87,27 @@ static Expression* expression(ASTParser* parser);
  */
 static Literal* identifierLiteral(ASTParser* parser) {
     Token* identifier = consume(parser, TOKEN_IDENTIFIER, "Expected identifier.");
-    IdentifierLiteral* tempIdentifierLiteral = allocateASTNode(IdentifierLiteral);
-    tempIdentifierLiteral->token = *(identifier);
+    IdentifierLiteral* identifierLiteral = allocateASTNode(IdentifierLiteral);
+    identifierLiteral->token = *(identifier);
 
     Literal* literal = allocateASTNode(Literal);
     literal->type = IDENTIFIER_LITERAL;
-    literal->as.identifierLiteral = tempIdentifierLiteral;
+    literal->as.identifierLiteral = identifierLiteral;
+
+    return literal;
+}
+
+/**
+ * Terminal rule. Match string token.
+ */
+static Literal* stringLiteral(ASTParser* parser) {
+    Token* string = consume(parser, TOKEN_STRING, "Expected string.");
+    StringLiteral* stringLiteral = allocateASTNode(StringLiteral);
+    stringLiteral->token = *(string);
+
+    Literal* literal = allocateASTNode(Literal);
+    literal->type = STRING_LITERAL;
+    literal->as.stringLiteral = stringLiteral;
 
     return literal;
 }
@@ -169,6 +184,20 @@ static Expression* primaryExpression(ASTParser* parser) {
             expression->as.primaryExpression = primaryExpression;
 
             return expression;
+            break;
+        }
+        case TOKEN_STRING: {
+            Literal* tempLiteral = stringLiteral(parser);
+
+            Expression* expression = allocateASTNode(Expression);
+            expression->type = PRIMARY_EXPRESSION;
+
+            PrimaryExpression* primaryExpression = allocateASTNode(PrimaryExpression);
+            primaryExpression->literal = tempLiteral;
+
+            expression->as.primaryExpression = primaryExpression;
+            return expression;
+            break;
         }
         case TOKEN_TRUE:
         case TOKEN_FALSE: {

--- a/src/vm.c
+++ b/src/vm.c
@@ -63,6 +63,7 @@ Value bytecodeConstantToValue(VM* vm, size_t constantIndex) {
         case CONST_TYPE_DOUBLE:
             return (Value){.type = TYPE_DOUBLE, .as = {.doubleVal = constant.as.number}};
         case CONST_TYPE_STRING:
+        case CONST_TYPE_IDENTIFIER:
             return (Value){.type = TYPE_STRING, .as = {.stringVal = constant.as.string}};
     }
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -73,12 +73,14 @@ static void printValue(Value value) {
         case TYPE_DOUBLE:
             printf("%f", value.as.doubleVal);
             break;
-
         case TYPE_BOOLEAN:
             printf("%s", value.as.booleanVal ? "true" : "false");
             break;
-
-        default:
+        case TYPE_NULL:
+            printf("null");
+            break;
+        case TYPE_STRING:
+            printf("%s", value.as.stringVal);
             break;
     };
 }

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -61,6 +61,7 @@ static void all_tests() {
     RUN_TEST(test_vm_boolean_truthiness);
     RUN_TEST(test_vm_unary_not);
     RUN_TEST(test_vm_unary_negation);
+    RUN_TEST(test_vm_print_string_literal);
 }
 
 int main(int argc, char **argv) {

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -30,6 +30,7 @@ static void all_tests() {
     RUN_TEST(test_compiler_multiplicative_expressions);
     RUN_TEST(test_compiler_unary_expressions);
     RUN_TEST(test_compiler_boolean_literal);
+    RUN_TEST(test_compiler_string_literal);
 
     // RUN_TEST(test_parser_errorHandling);
     RUN_TEST(test_parser_simple_expression);

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -9,30 +9,19 @@
 #include "src/vm_test.c"
 
 static void all_tests() {
+    // Array (util) tests
     RUN_TEST(test_array);
 
+    // Hash table (util) tests
     RUN_TEST(test_hashTable_init);
     RUN_TEST(test_hashTable_insert_and_get);
     RUN_TEST(test_hashTable_delete);
     RUN_TEST(test_hashTable_resize);
 
+    // Scanner tests
     RUN_TEST(test_scanner);
 
-    RUN_TEST(test_compiler);
-    RUN_TEST(test_compiler_print);
-    RUN_TEST(test_compiler_val_declaration);
-    RUN_TEST(test_compiler_variable_declaration_and_printing);
-    RUN_TEST(test_add_constant_to_pool_no_duplicates);
-    RUN_TEST(test_compiler_binary_equal);
-    RUN_TEST(test_compiler_binary_not_equal);
-    RUN_TEST(test_compiler_comparison_operations);
-    RUN_TEST(test_compiler_logical_and_or_operations);
-    RUN_TEST(test_compiler_multiplicative_expressions);
-    RUN_TEST(test_compiler_unary_expressions);
-    RUN_TEST(test_compiler_boolean_literal);
-    RUN_TEST(test_compiler_string_literal);
-
-    // RUN_TEST(test_parser_errorHandling);
+    // Parser tests
     RUN_TEST(test_parser_simple_expression);
     RUN_TEST(test_parser_print_statement);
     RUN_TEST(test_parser_logical_or_expression);
@@ -47,6 +36,22 @@ static void all_tests() {
     RUN_TEST(test_parser_variable_declaration_and_reading);
     RUN_TEST(test_parser_string_literal);
 
+    // Compiler tests
+    RUN_TEST(test_compiler);
+    RUN_TEST(test_compiler_print);
+    RUN_TEST(test_compiler_val_declaration);
+    RUN_TEST(test_compiler_variable_declaration_and_printing);
+    RUN_TEST(test_add_constant_to_pool_no_duplicates);
+    RUN_TEST(test_compiler_binary_equal);
+    RUN_TEST(test_compiler_binary_not_equal);
+    RUN_TEST(test_compiler_comparison_operations);
+    RUN_TEST(test_compiler_logical_and_or_operations);
+    RUN_TEST(test_compiler_multiplicative_expressions);
+    RUN_TEST(test_compiler_unary_expressions);
+    RUN_TEST(test_compiler_boolean_literal);
+    RUN_TEST(test_compiler_string_literal);
+
+    // VM tests
     RUN_TEST(test_vm_addition);
     RUN_TEST(test_vm_print);
     RUN_TEST(test_vm_set_and_get_global);

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -44,6 +44,7 @@ static void all_tests() {
     RUN_TEST(test_parser_complex_expression);
     RUN_TEST(test_parser_nested_parentheses_expression);
     RUN_TEST(test_parser_variable_declaration_and_reading);
+    RUN_TEST(test_parser_string_literal);
 
     RUN_TEST(test_vm_addition);
     RUN_TEST(test_vm_print);

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -326,7 +326,7 @@ int test_compiler_variable_declaration_and_printing() {
 
     ASSERT(compiledCode.constantPool.values[0].type == CONST_TYPE_DOUBLE);  // 42
     ASSERT(compiledCode.constantPool.values[0].as.number == 42);
-    ASSERT(compiledCode.constantPool.values[1].type == CONST_TYPE_STRING);  // x
+    ASSERT(compiledCode.constantPool.values[1].type == CONST_TYPE_IDENTIFIER);  // x
 
     FREE_ARRAY(compiledCode.bytecodeArray);
     FREE_ARRAY(compiledCode.constantPool);

--- a/test/unit/src/parser_test.c
+++ b/test/unit/src/parser_test.c
@@ -602,3 +602,37 @@ int test_parser_variable_declaration_and_reading() {
 
     return SUCCESS_RETURN_CODE;
 }
+
+int test_parser_string_literal() {
+    TokenType types[] = {TOKEN_STRING, TOKEN_SEMICOLON, TOKEN_EOF};
+    const char* lexemes[] = {"\"Hello, World!\"", ";", ""};
+
+    TokenArray tokens;
+    INIT_ARRAY(tokens, Token);
+
+    for (int i = 0; i < sizeof(types) / sizeof(TokenType); ++i) {
+        Token token = createToken(types[i], lexemes[i]);
+        INSERT_ARRAY(tokens, token, Token);
+    }
+
+    ASTParser parser;
+    Source* source = parseASTFromTokens(&parser, &tokens);
+
+    // Check that the AST correctly represents a string literal expression
+    ASSERT(source->numberOfStatements == 1);
+    Statement* statement = source->rootStatements[0];
+    ASSERT(statement->type == EXPRESSION_STATEMENT);
+
+    Expression* expression = statement->as.expressionStatement->expression;
+    ASSERT(expression->type == PRIMARY_EXPRESSION);
+
+    PrimaryExpression* primaryExpression = expression->as.primaryExpression;
+    ASSERT(primaryExpression->literal->type == STRING_LITERAL);
+    ASSERT(strcmp(primaryExpression->literal->as.stringLiteral->token.start, "\"Hello, World!\"") == 0);
+
+    // Cleanup
+    freeSource(source);
+    FREE_ARRAY(tokens);
+
+    return SUCCESS_RETURN_CODE;
+}

--- a/test/unit/src/parser_test.c
+++ b/test/unit/src/parser_test.c
@@ -102,23 +102,6 @@ int test_parser_print_statement() {
     return SUCCESS_RETURN_CODE;
 }
 
-// TODO: fill out this test
-int test_parser_errorHandling() {
-    TokenType types[] = {TOKEN_NUMBER, TOKEN_PLUS, TOKEN_EOF};
-    TokenArray tokens = createTokenArray(types, 3);
-
-    ASTParser parser;
-    initASTParser(&parser, tokens);
-
-    // You should set up an environment to catch the error or simulate it
-    // Then call parseAST and assert the expected behavior
-
-    FREE_ARRAY(tokens);
-    // Free other resources if necessary
-
-    return SUCCESS_RETURN_CODE;
-}
-
 // Example function to test parsing of a logical OR expression, including detailed assertions
 int test_parser_logical_or_expression() {
     Token tokensArray[] = {

--- a/test/unit/src/vm_test.c
+++ b/test/unit/src/vm_test.c
@@ -371,3 +371,41 @@ int test_vm_unary_not() {
 
     return SUCCESS_RETURN_CODE;
 }
+
+int test_vm_print_string_literal() {
+    // Setup the VM and bytecode for a simple program that prints "Hello, World!"
+    CompiledCode code = {.constantPool = {}, .bytecodeArray = {}};
+    INIT_ARRAY(code.bytecodeArray, Bytecode);
+    INIT_ARRAY(code.constantPool, Constant);
+
+    // Assuming you have a function to add a string to the constant pool and return its index
+    INSERT_ARRAY(code.constantPool, STRING_CONST("Hello, World!\0"), Constant);  // Index 0
+
+    // Assuming you have specific bytecode operations for loading a constant and printing
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_PRINT), Bytecode);
+
+    // Initialize VM with the bytecode
+    VM vm;
+    initVM(&vm, code);
+
+    // Redirect stdout to a buffer to capture the output
+    char buffer[1024];
+    freopen("/dev/null", "a", stdout);  // Prevent actual printing to stdout
+    setbuf(stdout, buffer);
+
+    // Run the VM
+    run(&vm);
+
+    // Restore stdout
+    freopen("/dev/tty", "a", stdout);
+
+    // Check if the buffer contains the expected string
+    ASSERT(strcmp(buffer, "Hello, World!") == 0);
+
+    // Cleanup
+    FREE_ARRAY(code.bytecodeArray);
+    FREE_ARRAY(code.constantPool);
+
+    return SUCCESS_RETURN_CODE;
+}


### PR DESCRIPTION
### Summary
Add support for string literals.

### Tests
Added unit tests for parser, compiler, vm.

Also tested manually:

```
> print "Hello!";
Tokens:
  TOKEN_PRINT(lexeme="print", line=1, column=6)
  TOKEN_STRING(lexeme=""Hello!"", line=1, column=15)
  TOKEN_SEMICOLON(lexeme=";", line=1, column=16)
  TOKEN_EOF(lexeme="", line=2, column=2)

AST
Source(numberOfStatements=1)
|   PrintStatement
|   |   PrimaryExpression
|   |   |   StringLiteral(token="Hello!")

Started compiling.
Done compiling in 0.00001 seconds.

Compiled code:
Constant Pool 
 #0 (string) "Hello!"
Bytecode
 [ LOAD_CONSTANT #0 ]
 [ PRINT ]

Hello!
```