### PR TITLE
Add block statements and fast local variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@
 *.i*86
 *.x86_64
 *.hex
-sol
+./sol
 unit_test
 
 # Debug files

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,7 +67,8 @@
     "colors.h": "c",
     "hash_table.h": "c",
     "vm.h": "c",
-    "typeinfo": "c"
+    "typeinfo": "c",
+    "limits.h": "c"
   },
   "C_Cpp.errorSquiggles": "enabled"
 }

--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ var uniqueNumberGenerator = struct {
 uniqueNumberGenerator.printNewNumbers(2);
 ```
 
-## Motivation
-
-SolScript is a toy programming language and a passion project. After finishing the book [Crafting Interpreters](https://craftinginterpreters.com/) and implementing the language Lox, I decided to create my own language. I had also just read [The C Programming Language](https://en.wikipedia.org/wiki/The_C_Programming_Language) and was motivated to work on another C project.
-
 ## Language Design
 
 The following diagram gives a high-level overview of SolScript's internals.

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ The following features are necessary a proper v1.0 release, in rough order:
  - [X] Implement additive expression
  - [X] Implement all other "simple" expressions, i.e. excluding call-expressions
  - [X] Implement string literals
+ - [ ] Implement block statements and expressions
  - [ ] Implement selection statement (`if`s)
  - [ ] Implement the rest of the parser for the whole syntax grammar
  - [ ] Add conditional debugging/logging for tests that fail
@@ -344,7 +345,6 @@ The following features are necessary a proper v1.0 release, in rough order:
  - [ ] Implement assignment statements
  - [ ] Add CLI argument to enable or disable debugging logs in the REPL.
  - [ ] Improve error logs; print line and column
- - [ ] Implement block statements and expressions
  - [ ] Implement iteration statement (loops)
  - [ ] Add Panic Mode error recovery; stop crashing the compiler on every error.
  - [ ] Implement objects / structs

--- a/README.md
+++ b/README.md
@@ -333,7 +333,8 @@ The following features are necessary a proper v1.0 release, in rough order:
  - [X] Implement additive expression
  - [X] Implement all other "simple" expressions, i.e. excluding call-expressions
  - [X] Implement string literals
- - [ ] Implement block statements and expressions
+ - [X] Implement block statements and expressions
+ - [X] Add [_FAST](https://stackoverflow.com/questions/74998947/whats-pythons-load-fast-bytecode-instruction-fast-at) local variables
  - [ ] Implement selection statement (`if`s)
  - [ ] Implement the rest of the parser for the whole syntax grammar
  - [ ] Add conditional debugging/logging for tests that fail

--- a/code.sol
+++ b/code.sol
@@ -1,4 +1,35 @@
 // Example code
-{ val a=2; print a;}
-{ val a=2; print a;}
-{ val a=2; print a;}
+{ 
+    val a = 2; 
+    print a;
+}
+{ 
+    val a = 3; 
+    print a;
+}
+{ 
+    val a = 4; 
+    print a;
+}
+{
+    val b = 5;
+    {
+        print b;
+    }
+}
+{
+    val b = 6;
+    {
+        {
+            print b;
+        }
+    }
+}
+val c = 7;
+{
+    {
+        {
+            print c;
+        }
+    }
+}

--- a/code.sol
+++ b/code.sol
@@ -1,2 +1,2 @@
 // Example code
-val d = "a";
+{ print 1+1; }

--- a/code.sol
+++ b/code.sol
@@ -1,35 +1,13 @@
-// Example code
-{ 
-    val a = 2; 
-    print a;
-}
-{ 
-    val a = 3; 
-    print a;
-}
-{ 
-    val a = 4; 
-    print a;
-}
+val g = 100;
+print g;
 {
-    val b = 5;
+    print g;
+    val x = 10;
+    print x;
     {
-        print b;
-    }
-}
-{
-    val b = 6;
-    {
-        {
-            print b;
-        }
-    }
-}
-val c = 7;
-{
-    {
-        {
-            print c;
-        }
+        val g = 20;
+        print g;
+        val y = 30;
+        print y;
     }
 }

--- a/code.sol
+++ b/code.sol
@@ -1,2 +1,4 @@
 // Example code
-{ print 1+1; }
+{ val a=2; print a;}
+{ val a=2; print a;}
+{ val a=2; print a;}

--- a/src/bytecode.h
+++ b/src/bytecode.h
@@ -18,6 +18,7 @@ typedef enum {
     OP_TRUE,           // put Value true on the stack
     OP_FALSE,          // put Value false on the stack
     OP_PRINT,          // print value at the top of the stack
+    OP_POPN,           // pop N values from the stack
 
     // Unary operations
     OP_UNARY_NEGATE,  // -stack[-1]
@@ -43,16 +44,16 @@ typedef enum {
     (Bytecode) { .type = op }
 
 // Create bytecode with one constant
-#define BYTECODE_CONSTANT_1(op, index1) \
-    (Bytecode) {                        \
-        .type = op,                     \
-        .maybeConstantIndex = (index1)  \
+#define BYTECODE_OPERAND_1(op, index1) \
+    (Bytecode) {                       \
+        .type = op,                    \
+        .maybeOperand1 = (index1)      \
     }
 
 /* The bytecode contains the Opcode and optional operands depending on the type of operation. */
 typedef struct {
     Opcode type;
-    size_t maybeConstantIndex;
+    size_t maybeOperand1;
 } Bytecode;
 
 typedef struct {

--- a/src/bytecode.h
+++ b/src/bytecode.h
@@ -12,13 +12,15 @@
  * TODO: benchmark OP_BINARY(op) instead of OP_BINARY*
  */
 typedef enum {
-    OP_LOAD_CONSTANT,   // load a constant from the compiled constant pool onto the stack
-    OP_SET_GLOBAL_VAL,  // expects an identifier at the top of the stack, and a value right below it
-    OP_GET_GLOBAL_VAL,  // expects an identifier at the top of the stack
-    OP_TRUE,            // put Value true on the stack
-    OP_FALSE,           // put Value false on the stack
-    OP_PRINT,           // print value at the top of the stack
-    OP_POPN,            // pop N values from the stack
+    OP_LOAD_CONSTANT,       // load a constant from the compiled constant pool onto the stack
+    OP_SET_GLOBAL_VAL,      // expects an identifier at the top of the stack, and a value right below it
+    OP_GET_GLOBAL_VAL,      // expects an identifier at the top of the stack
+    OP_SET_LOCAL_VAL_FAST,  // turn the value at the top of the stack into a local variable.
+    OP_GET_LOCAL_VAL_FAST,  // load a local variable that's already in the stack
+    OP_TRUE,                // put Value true on the stack
+    OP_FALSE,               // put Value false on the stack
+    OP_PRINT,               // print value at the top of the stack
+    OP_POPN,                // pop N values from the stack
 
     // Unary operations
     OP_UNARY_NEGATE,  // -stack[-1]

--- a/src/bytecode.h
+++ b/src/bytecode.h
@@ -12,13 +12,13 @@
  * TODO: benchmark OP_BINARY(op) instead of OP_BINARY*
  */
 typedef enum {
-    OP_LOAD_CONSTANT,  // load a constant from the compiled constant pool onto the stack
-    OP_SET_VAL,        // expects an identifier at the top of the stack, and a value right below it
-    OP_GET_VAL,        // expects an identifier at the top of the stack
-    OP_TRUE,           // put Value true on the stack
-    OP_FALSE,          // put Value false on the stack
-    OP_PRINT,          // print value at the top of the stack
-    OP_POPN,           // pop N values from the stack
+    OP_LOAD_CONSTANT,   // load a constant from the compiled constant pool onto the stack
+    OP_SET_GLOBAL_VAL,  // expects an identifier at the top of the stack, and a value right below it
+    OP_GET_GLOBAL_VAL,  // expects an identifier at the top of the stack
+    OP_TRUE,            // put Value true on the stack
+    OP_FALSE,           // put Value false on the stack
+    OP_PRINT,           // print value at the top of the stack
+    OP_POPN,            // pop N values from the stack
 
     // Unary operations
     OP_UNARY_NEGATE,  // -stack[-1]

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -20,7 +20,7 @@ void initCompiler(Compiler* compiler, Source* ASTSource) {
     compiler->compiledBytecode = bytecodeArray;
     compiler->ASTSource = ASTSource;
     compiler->constantPool = constantPool;
-    compiler->currentStackLevel = 0;
+    compiler->currentStackHeight = 0;
 }
 
 /* FORWARD DECLARATIONS */
@@ -53,11 +53,11 @@ static void emitBytecode(Compiler* compiler, Bytecode bytecode) {
  * of the height. For example, a local variable declaration increases the stack by 1 (locals live on the stack).
  */
 static void increaseStackHeight(Compiler* compiler) {
-    if (compiler->currentStackLevel == UCHAR_MAX) {
+    if (compiler->currentStackHeight == UCHAR_MAX) {
         errorAndExit("Compiler error: VM stack will overflow.");
     }
 
-    compiler->currentStackLevel++;
+    compiler->currentStackHeight++;
 }
 
 /**
@@ -65,7 +65,7 @@ static void increaseStackHeight(Compiler* compiler) {
  * of the height. For example, an addition decreases the height of the stack by 1 (pop, pop, push).
  */
 static void decreaseStackHeight(Compiler* compiler) {
-    compiler->currentStackLevel--;
+    compiler->currentStackHeight--;
 }
 
 static double tokenTodouble(Token token) {
@@ -261,7 +261,7 @@ static void visitPrintStatement(Compiler* compiler, PrintStatement* printStateme
 
 static void visitBlockStatement(Compiler* compiler, BlockStatement* blockStatement) {
     // Keep track of the stack height so we can later pop all the variables etc defined in it.
-    uint8_t stackHeightBeforeBlockStmt = compiler->currentStackLevel;
+    uint8_t stackHeightBeforeBlockStmt = compiler->currentStackHeight;
 
     for (size_t i = 0; i < blockStatement->statementArray.used; i++) {
         Statement* statement = blockStatement->statementArray.values[i];
@@ -269,7 +269,7 @@ static void visitBlockStatement(Compiler* compiler, BlockStatement* blockStateme
     }
 
     // Pop all the Values that were put in the stack in the block.
-    uint8_t stackHeightAfterBlockStmt = compiler->currentStackLevel;
+    uint8_t stackHeightAfterBlockStmt = compiler->currentStackHeight;
     uint8_t blockStmtStackEffect = stackHeightAfterBlockStmt - stackHeightBeforeBlockStmt;
     emitBytecode(compiler, BYTECODE_OPERAND_1(OP_POPN, blockStmtStackEffect));
 }

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -275,7 +275,8 @@ static void visitPrimaryExpression(Compiler* compiler, PrimaryExpression* primar
 static void visitExpressionStatement(Compiler* compiler, ExpressionStatement* expressionStatement) {
     visitExpression(compiler, expressionStatement->expression);
 
-    // The expression will always add a Value to the stack. We remove it because it's unreacheable and thus useless.
+    // The expression will always add a Value to the stack, but by definition it's not used
+    // (otherwise it wouldn't be an expression statement) so we need to remove it.
     emitBytecode(compiler, BYTECODE_OPERAND_1(OP_POPN, 1));
     decreaseStackHeight(compiler);
 }
@@ -286,7 +287,7 @@ static void visitExpressionStatement(Compiler* compiler, ExpressionStatement* ex
  */
 static void visitValDeclarationStatement(Compiler* compiler, ValDeclarationStatement* valDeclarationStatement) {
     visitExpression(compiler, valDeclarationStatement->expression);
-    // The expression will add 1 to the stack height. We leave that value on the stack - that's the variable.
+    // The expression will add 1 to the stack height. We leave the value on the stack - that's the variable.
 
     Constant constant = IDENTIFIER_CONST(copyStringToHeap(valDeclarationStatement->identifier->token.start,
                                                           valDeclarationStatement->identifier->token.length));

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -1,6 +1,8 @@
 #ifndef sol_script_compiler_h
 #define sol_script_compiler_h
 
+#include <stdbool.h>
+
 #include "bytecode.h"
 #include "syntax.h"
 #include "token.h"
@@ -16,6 +18,8 @@ typedef struct {
     ConstantPool constantPool;
     Source* ASTSource;  // Root of the AST
     u_int8_t currentStackHeight;
+    bool isInGlobalScope;  // Track whether the compiler is currently in the global scope instead of in a block.
+                           // This is used to distinguish between local variables and global variables.
 } Compiler;
 
 /* Initialize a Compiler with an AST to be parsed */

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -7,11 +7,15 @@
 
 /**
  * Compiler struct to facilitate compiling an AST into bytecode.
+ *
+ * @param currentStackLevel tracks the height of the VM stack at this point of compilation, starting at zero. (The compiler
+ *                          can know in advance how tall the stack will be.)
  */
 typedef struct {
     BytecodeArray compiledBytecode;
     ConstantPool constantPool;
     Source* ASTSource;  // Root of the AST
+    u_int8_t currentStackLevel;
 } Compiler;
 
 /* Initialize a Compiler with an AST to be parsed */

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -31,7 +31,7 @@ typedef struct {
     bool isInGlobalScope;  // Track whether the compiler is currently in the global scope instead of in a block.
                            // This is used to distinguish between local variables and global variables.
 
-    u_int8_t currentStackHeight;  // The next empty spot in the stack
+    u_int8_t currentStackHeight;  // The next empty spot on the stack
     Local tempStack[STACK_MAX];   // A copy of the VM's stack so we can know at compile time what position
                                   // local variables will be in. Holds only strings for variable names.
 } Compiler;

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -7,6 +7,16 @@
 #include "syntax.h"
 #include "token.h"
 
+#define STACK_MAX 256
+
+/**
+ * Represents a local variable in the temporary stack maintained by the compiler.
+ * This exists so we can optimize local variable access.
+ */
+typedef struct {
+    char* name;  // Null-terminated
+} Local;
+
 /**
  * Compiler struct to facilitate compiling an AST into bytecode.
  *
@@ -17,9 +27,13 @@ typedef struct {
     BytecodeArray compiledBytecode;
     ConstantPool constantPool;
     Source* ASTSource;  // Root of the AST
-    u_int8_t currentStackHeight;
+
     bool isInGlobalScope;  // Track whether the compiler is currently in the global scope instead of in a block.
                            // This is used to distinguish between local variables and global variables.
+
+    u_int8_t currentStackHeight;  // The next empty spot in the stack
+    Local tempStack[STACK_MAX];   // A copy of the VM's stack so we can know at compile time what position
+                                  // local variables will be in. Holds only strings for variable names.
 } Compiler;
 
 /* Initialize a Compiler with an AST to be parsed */

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -8,14 +8,14 @@
 /**
  * Compiler struct to facilitate compiling an AST into bytecode.
  *
- * @param currentStackLevel tracks the height of the VM stack at this point of compilation, starting at zero. (The compiler
+ * @param currentStackHeight tracks the height of the VM stack at this point of compilation, starting at zero. (The compiler
  *                          can know in advance how tall the stack will be.)
  */
 typedef struct {
     BytecodeArray compiledBytecode;
     ConstantPool constantPool;
     Source* ASTSource;  // Root of the AST
-    u_int8_t currentStackLevel;
+    u_int8_t currentStackHeight;
 } Compiler;
 
 /* Initialize a Compiler with an AST to be parsed */

--- a/src/config.h
+++ b/src/config.h
@@ -1,7 +1,7 @@
 #ifndef sol_script_config_h
 #define sol_script_config_h
 
-#define DEBUG_COMPILER 1
+#define DEBUG_COMPILER 0
 // #define DEBUG_VM
 
 #endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -292,6 +292,9 @@ static void printBytecodeArray(BytecodeArray bytecodeArray) {
             case OP_GET_VAL:
                 printf(" [ OP_GET_VAL #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
                 break;
+            case OP_POPN:
+                printf(" [ OP_POPN #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
+                break;
             case OP_PRINT:
                 printf(" [ PRINT ]\n");
                 break;

--- a/src/debug.c
+++ b/src/debug.c
@@ -292,6 +292,12 @@ static void printBytecodeArray(BytecodeArray bytecodeArray) {
             case OP_GET_GLOBAL_VAL:
                 printf(" [ OP_GET_GLOBAL_VAL #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
                 break;
+            case OP_SET_LOCAL_VAL_FAST:
+                printf(" [ OP_SET_LOCAL_VAL_FAST ]\n");
+                break;
+            case OP_GET_LOCAL_VAL_FAST:
+                printf(" [ OP_GET_LOCAL_VAL_FAST #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
+                break;
             case OP_POPN:
                 printf(" [ OP_POPN #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
                 break;

--- a/src/debug.c
+++ b/src/debug.c
@@ -299,7 +299,7 @@ static void printBytecodeArray(BytecodeArray bytecodeArray) {
                 printf(" [ OP_GET_LOCAL_VAL_FAST #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
                 break;
             case OP_POPN:
-                printf(" [ OP_POPN #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
+                printf(" [ OP_POPN %zu ]\n", bytecodeArray.values[i].maybeOperand1);
                 break;
             case OP_PRINT:
                 printf(" [ PRINT ]\n");

--- a/src/debug.c
+++ b/src/debug.c
@@ -138,6 +138,12 @@ static void printStatement(const Statement* statement, int depth) {
             printf("PrintStatement\n");
             printExpression(statement->as.printStatement->expression, depth + 1);
             break;
+        case BLOCK_STATEMENT:
+            printf("BlockStatement" KGRY "(numberOfStatements=%zu)\n" RESET, statement->as.blockStatement->statementArray.used);
+            for (int i = 0; i < statement->as.blockStatement->statementArray.used; ++i) {
+                printStatement(statement->as.blockStatement->statementArray.values[i], depth + 1);
+            }
+            break;
     }
 }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -284,13 +284,13 @@ static void printBytecodeArray(BytecodeArray bytecodeArray) {
     for (int i = 0; i < bytecodeArray.used; i++) {
         switch (bytecodeArray.values[i].type) {
             case OP_LOAD_CONSTANT:
-                printf(" [ LOAD_CONSTANT #%zu ]\n", bytecodeArray.values[i].maybeConstantIndex);
+                printf(" [ LOAD_CONSTANT #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
                 break;
             case OP_SET_VAL:
-                printf(" [ OP_SET_VAL #%zu ]\n", bytecodeArray.values[i].maybeConstantIndex);
+                printf(" [ OP_SET_VAL #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
                 break;
             case OP_GET_VAL:
-                printf(" [ OP_GET_VAL #%zu ]\n", bytecodeArray.values[i].maybeConstantIndex);
+                printf(" [ OP_GET_VAL #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
                 break;
             case OP_PRINT:
                 printf(" [ PRINT ]\n");

--- a/src/debug.c
+++ b/src/debug.c
@@ -286,11 +286,11 @@ static void printBytecodeArray(BytecodeArray bytecodeArray) {
             case OP_LOAD_CONSTANT:
                 printf(" [ LOAD_CONSTANT #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
                 break;
-            case OP_SET_VAL:
-                printf(" [ OP_SET_VAL #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
+            case OP_SET_GLOBAL_VAL:
+                printf(" [ OP_SET_GLOBAL_VAL #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
                 break;
-            case OP_GET_VAL:
-                printf(" [ OP_GET_VAL #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
+            case OP_GET_GLOBAL_VAL:
+                printf(" [ OP_GET_GLOBAL_VAL #%zu ]\n", bytecodeArray.values[i].maybeOperand1);
                 break;
             case OP_POPN:
                 printf(" [ OP_POPN #%zu ]\n", bytecodeArray.values[i].maybeOperand1);

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -4,9 +4,16 @@
 #include "token.h"
 #include "util/array.h"
 
+typedef struct {
+    Statement *values;
+    size_t used;
+    size_t size;
+} StatementArray;
+
 // Forward declarations
 typedef struct ExpressionStatement ExpressionStatement;
 typedef struct PrintStatement PrintStatement;
+typedef struct BlockStatement BlockStatement;
 typedef struct ValDeclarationStatement ValDeclarationStatement;
 typedef struct LogicalOrExpression LogicalOrExpression;
 typedef struct LogicalAndExpression LogicalAndExpression;
@@ -25,7 +32,8 @@ typedef struct StringLiteral StringLiteral;
 typedef enum {
     EXPRESSION_STATEMENT,
     VAL_DECLARATION_STATEMENT,
-    PRINT_STATEMENT
+    PRINT_STATEMENT,
+    BLOCK_STATEMENT
 } StatementType;
 
 typedef enum {
@@ -53,6 +61,7 @@ typedef struct {
         ExpressionStatement *expressionStatement;
         ValDeclarationStatement *valDeclarationStatement;
         PrintStatement *printStatement;
+        BlockStatement *blockStatement;
     } as;
 } Statement;
 
@@ -83,6 +92,10 @@ typedef struct {
 // --- Concrete productions ---
 struct ExpressionStatement {
     Expression *expression;
+};
+
+struct BlockStatement {
+    Statement *StatementArray;
 };
 
 struct PrintStatement {

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -26,7 +26,7 @@ typedef struct StringLiteral StringLiteral;
 // (Stack effect is how the instruction modifies the stack, +1 means it adds something to the stack.)
 typedef enum {
     EXPRESSION_STATEMENT,       // Stack effect: 0
-    VAL_DECLARATION_STATEMENT,  // Stack effect: +1
+    VAL_DECLARATION_STATEMENT,  // Stack effect: +1 if local, 0 if global.
     PRINT_STATEMENT,            // Stack effect: 0
     BLOCK_STATEMENT             // Stack effect: 0
 } StatementType;

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -4,12 +4,6 @@
 #include "token.h"
 #include "util/array.h"
 
-typedef struct {
-    Statement *values;
-    size_t used;
-    size_t size;
-} StatementArray;
-
 // Forward declarations
 typedef struct ExpressionStatement ExpressionStatement;
 typedef struct PrintStatement PrintStatement;
@@ -94,8 +88,14 @@ struct ExpressionStatement {
     Expression *expression;
 };
 
+typedef struct {
+    Statement **values;
+    size_t used;
+    size_t size;
+} StatementArray;
+
 struct BlockStatement {
-    Statement *StatementArray;
+    StatementArray statementArray;
 };
 
 struct PrintStatement {

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -23,29 +23,30 @@ typedef struct IdentifierLiteral IdentifierLiteral;
 typedef struct StringLiteral StringLiteral;
 
 // --- Types ---
+// (Stack effect is how the instruction modifies the stack, +1 means it adds something to the stack.)
 typedef enum {
-    EXPRESSION_STATEMENT,
-    VAL_DECLARATION_STATEMENT,
-    PRINT_STATEMENT,
-    BLOCK_STATEMENT
+    EXPRESSION_STATEMENT,       // Stack effect: 0
+    VAL_DECLARATION_STATEMENT,  // Stack effect: +1
+    PRINT_STATEMENT,            // Stack effect: 0
+    BLOCK_STATEMENT             // Stack effect: 0
 } StatementType;
 
 typedef enum {
-    LOGICAL_OR_EXPRESSION,
-    LOGICAL_AND_EXPRESSION,
-    EQUALITY_EXPRESSION,
-    COMPARISON_EXPRESSION,
-    ADDITIVE_EXPRESSION,
-    MULTIPLICATIVE_EXPRESSION,
-    UNARY_EXPRESSION,
-    PRIMARY_EXPRESSION
+    LOGICAL_OR_EXPRESSION,      // Stack effect: -1
+    LOGICAL_AND_EXPRESSION,     // Stack effect: -1
+    EQUALITY_EXPRESSION,        // Stack effect: -1
+    COMPARISON_EXPRESSION,      // Stack effect: -1
+    ADDITIVE_EXPRESSION,        // Stack effect: -1
+    MULTIPLICATIVE_EXPRESSION,  // Stack effect: -1
+    UNARY_EXPRESSION,           // Stack effect: 0
+    PRIMARY_EXPRESSION          // Stack effect: 0 per se
 } ExpressionType;
 
 typedef enum {
-    BOOLEAN_LITERAL,
-    NUMBER_LITERAL,
-    IDENTIFIER_LITERAL,
-    STRING_LITERAL
+    BOOLEAN_LITERAL,     // Stack effect: +1
+    NUMBER_LITERAL,      // Stack effect: +1
+    IDENTIFIER_LITERAL,  // Stack effect: +1
+    STRING_LITERAL       // Stack effect: +1
 } LiteralType;
 
 // --- Abstract productions ---

--- a/src/vm.c
+++ b/src/vm.c
@@ -160,6 +160,14 @@ void step(VM* vm) {
             push(vm, value);
             break;
         }
+        case OP_SET_LOCAL_VAL_FAST:
+            break;  // no action necessary to set locals. The compiler handles everything. 🤯
+        case OP_GET_LOCAL_VAL_FAST: {
+            size_t stackIndex = instruction->maybeOperand1;
+            Value value = vm->stack[stackIndex];
+            push(vm, value);
+            break;
+        }
         case OP_POPN: {
             size_t n = instruction->maybeOperand1;
             popN(vm, n);

--- a/src/vm.c
+++ b/src/vm.c
@@ -48,6 +48,15 @@ Value pop(VM* vm) {
     vm->SP--;
     return *(vm->SP);
 }
+
+// Pop N values from the stack
+void popN(VM* vm, int n) {
+    if (n > (vm->SP - vm->stack)) {
+        runtimeError(vm, "Runtime error: attempted to pop more elements from the stack than are in the stack.");
+    }
+    vm->SP -= n;
+}
+
 /**
  * peek(0) peeks the top of the stack
  * peek(1) peeks the second highest element of the stack
@@ -149,6 +158,11 @@ void step(VM* vm) {
             Constant constant = vm->compiledCode.constantPool.values[constantIndex];
             Value value = hashTableGet(&vm->globals, constant.as.string)->value;
             push(vm, value);
+            break;
+        }
+        case OP_POPN: {
+            size_t n = instruction->maybeOperand1;
+            popN(vm, n);
             break;
         }
         case OP_PRINT: {

--- a/src/vm.c
+++ b/src/vm.c
@@ -146,14 +146,14 @@ void step(VM* vm) {
         case OP_LOAD_CONSTANT:
             push(vm, bytecodeConstantToValue(vm, instruction->maybeOperand1));
             break;
-        case OP_SET_VAL: {
+        case OP_SET_GLOBAL_VAL: {
             Value value = pop(vm);
             size_t constantIndex = instruction->maybeOperand1;
             Constant constant = vm->compiledCode.constantPool.values[constantIndex];
             hashTableInsert(&vm->globals, constant.as.string, value);
             break;
         }
-        case OP_GET_VAL: {
+        case OP_GET_GLOBAL_VAL: {
             size_t constantIndex = instruction->maybeOperand1;
             Constant constant = vm->compiledCode.constantPool.values[constantIndex];
             Value value = hashTableGet(&vm->globals, constant.as.string)->value;

--- a/src/vm.c
+++ b/src/vm.c
@@ -93,6 +93,7 @@ static void printValue(Value value) {
             printf("%s", value.as.stringVal);
             break;
     };
+    printf("\n");
 }
 
 // Apply an operation to two doubles, push double to stack

--- a/src/vm.c
+++ b/src/vm.c
@@ -135,17 +135,17 @@ void step(VM* vm) {
 
     switch (instruction->type) {
         case OP_LOAD_CONSTANT:
-            push(vm, bytecodeConstantToValue(vm, instruction->maybeConstantIndex));
+            push(vm, bytecodeConstantToValue(vm, instruction->maybeOperand1));
             break;
         case OP_SET_VAL: {
             Value value = pop(vm);
-            size_t constantIndex = instruction->maybeConstantIndex;
+            size_t constantIndex = instruction->maybeOperand1;
             Constant constant = vm->compiledCode.constantPool.values[constantIndex];
             hashTableInsert(&vm->globals, constant.as.string, value);
             break;
         }
         case OP_GET_VAL: {
-            size_t constantIndex = instruction->maybeConstantIndex;
+            size_t constantIndex = instruction->maybeOperand1;
             Constant constant = vm->compiledCode.constantPool.values[constantIndex];
             Value value = hashTableGet(&vm->globals, constant.as.string)->value;
             push(vm, value);

--- a/src/vm.h
+++ b/src/vm.h
@@ -15,6 +15,7 @@
  * @param compiledCode compiled code including bytecode array and constants pool.
  * @param IP the instruction pointer.
  * @param stack the stack for our stack-based VM.
+ * @param globals hash table containing global variables
  * @param SP the stack pointer (we use an actual pointer instead of an int index for faster dereferencing)
  * */
 typedef struct {

--- a/test/sol/errors/global_use_before_declaration.sol
+++ b/test/sol/errors/global_use_before_declaration.sol
@@ -1,0 +1,2 @@
+print a;
+// Error: identifier 'a' referenced before declaration.

--- a/test/sol/errors/local_use_before_declaration.sol
+++ b/test/sol/errors/local_use_before_declaration.sol
@@ -1,0 +1,4 @@
+{
+    print a;
+}
+// Error: identifier 'a' referenced before declaration.

--- a/test/sol/sample_code.sol
+++ b/test/sol/sample_code.sol
@@ -1,0 +1,44 @@
+
+val a = 1;
+val b = "2";
+val c = () => {
+    print 2;
+}
+
+var car = struct {
+    make: "Porsche";
+    printMake: () => { print this.make };
+}
+
+var carFactory = (_make) => {
+    struct {
+        make: _make
+    }
+}
+
+// This is a struct with make = "Volvo"
+var volvoCar = carFactory("Volvo");
+
+var animal = struct {
+    type: "Animal;
+}
+
+var horse = struct {
+    numLegs: 4;
+    prototype: animal;
+}
+
+// Prints "Animal"
+print horse.type;
+
+var count = 4;
+// Any value != 0 is truthy
+while (count){
+    print count;
+    if (count == 4) {
+        count = count - 2; 
+    }
+    count = count - 1;
+}
+
+	

--- a/test/sol/scope/consecutive_blocks.sol
+++ b/test/sol/scope/consecutive_blocks.sol
@@ -1,0 +1,13 @@
+// 'a' should never be the value from a block above.
+{ 
+    val a = 2; 
+    print a;
+}
+{ 
+    val a = 3; 
+    print a;
+}
+{ 
+    val a = 4; 
+    print a;
+}

--- a/test/sol/scope/global_vs_local.sol
+++ b/test/sol/scope/global_vs_local.sol
@@ -1,0 +1,8 @@
+val c = 7; // Global declaration
+{
+    {
+        {
+            print c; // Global access when not in global scope
+        }
+    }
+}

--- a/test/sol/scope/nested_blocks.sol
+++ b/test/sol/scope/nested_blocks.sol
@@ -1,0 +1,15 @@
+// The printed 'b' value should be the one declared in a block above.
+{
+    val b = 5;
+    {
+        print b;
+    }
+}
+{
+    val b = 6;
+    {
+        {
+            print b;
+        }
+    }
+}

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -51,6 +51,7 @@ static void all_tests() {
     RUN_TEST(test_compiler_unary_expressions);
     RUN_TEST(test_compiler_boolean_literal);
     RUN_TEST(test_compiler_string_literal);
+    RUN_TEST(test_compiler_stack_height_expression_and_val);
 
     // VM tests
     RUN_TEST(test_vm_addition);

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -52,6 +52,7 @@ static void all_tests() {
     RUN_TEST(test_compiler_boolean_literal);
     RUN_TEST(test_compiler_string_literal);
     RUN_TEST(test_compiler_stack_height_expression_and_val);
+    RUN_TEST(test_compiler_single_block_statement_with_locals);
 
     // VM tests
     RUN_TEST(test_vm_addition);

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -35,6 +35,7 @@ static void all_tests() {
     RUN_TEST(test_parser_nested_parentheses_expression);
     RUN_TEST(test_parser_variable_declaration_and_reading);
     RUN_TEST(test_parser_string_literal);
+    RUN_TEST(test_parser_block_statement);
 
     // Compiler tests
     RUN_TEST(test_compiler);

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -53,6 +53,7 @@ static void all_tests() {
     RUN_TEST(test_compiler_string_literal);
     RUN_TEST(test_compiler_stack_height_expression_and_val);
     RUN_TEST(test_compiler_single_block_statement_with_locals);
+    RUN_TEST(test_nested_blocks_with_global_and_local_vars);
 
     // VM tests
     RUN_TEST(test_vm_addition);

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -63,7 +63,7 @@ static void all_tests() {
     RUN_TEST(test_vm_boolean_truthiness);
     RUN_TEST(test_vm_unary_not);
     RUN_TEST(test_vm_unary_negation);
-    RUN_TEST(test_vm_print_string_literal);
+    // RUN_TEST(test_vm_print_string_literal); // This test is flaky
 }
 
 int main(int argc, char **argv) {

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -53,7 +53,7 @@ static void all_tests() {
     RUN_TEST(test_compiler_string_literal);
     RUN_TEST(test_compiler_stack_height_expression_and_val);
     RUN_TEST(test_compiler_single_block_statement_with_locals);
-    RUN_TEST(test_nested_blocks_with_global_and_local_vars);
+    RUN_TEST(test_compiler_nested_blocks_with_global_and_local_vars);
 
     // VM tests
     RUN_TEST(test_vm_addition);
@@ -65,6 +65,8 @@ static void all_tests() {
     RUN_TEST(test_vm_boolean_truthiness);
     RUN_TEST(test_vm_unary_not);
     RUN_TEST(test_vm_unary_negation);
+    RUN_TEST(test_vm_simple_block_statement_and_cleanup);
+    RUN_TEST(test_vm_nested_blocks_with_global_and_local_vars);
     // RUN_TEST(test_vm_print_string_literal); // This test is flaky
 }
 

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -65,9 +65,9 @@ static void all_tests() {
     RUN_TEST(test_vm_boolean_truthiness);
     RUN_TEST(test_vm_unary_not);
     RUN_TEST(test_vm_unary_negation);
+    RUN_TEST(test_vm_print_string_literal);
     RUN_TEST(test_vm_simple_block_statement_and_cleanup);
     RUN_TEST(test_vm_nested_blocks_with_global_and_local_vars);
-    // RUN_TEST(test_vm_print_string_literal); // This test is flaky
 }
 
 int main(int argc, char **argv) {

--- a/test/unit/minunit.h
+++ b/test/unit/minunit.h
@@ -3,6 +3,7 @@
 #define minunit_h
 
 #include <stdio.h>
+#include <time.h>
 
 #include "util/colors.h"
 
@@ -65,18 +66,21 @@ static int assertionsFailed = 0;
  *
  * @param tests a void function containing any number of tests.
  */
-#define RUN_SUITE(tests)                                                              \
-    do {                                                                              \
-        tests();                                                                      \
-        printf("\n");                                                                 \
-        printf("Assertions run: %d, failed: %d.\n", assertionsRun, assertionsFailed); \
-        printf("Tests run: %d, failed: %d.\n", testsRun, testsFailed);                \
-        if (testsFailed) {                                                            \
-            printf(KRED "FAILED\n" RESET);                                            \
-        } else {                                                                      \
-            printf(KGRN "PASSED\n" RESET);                                            \
-        }                                                                             \
-        return testsFailed != 0;                                                      \
+#define RUN_SUITE(tests)                                                                  \
+    do {                                                                                  \
+        clock_t startTime = clock();                                                      \
+        tests();                                                                          \
+        clock_t endTime = clock();                                                        \
+        double timeTaken = ((double)(endTime - startTime)) / CLOCKS_PER_SEC;              \
+        printf("\n");                                                                     \
+        printf("Assertions run: %d, failed: %d.\n", assertionsRun, assertionsFailed);     \
+        printf("Tests run: %d, failed: %d. (%.5fs)\n", testsRun, testsFailed, timeTaken); \
+        if (testsFailed) {                                                                \
+            printf(KRED "FAILED\n" RESET);                                                \
+        } else {                                                                          \
+            printf(KGRN "PASSED\n" RESET);                                                \
+        }                                                                                 \
+        return testsFailed != 0;                                                          \
     } while (0)
 
 #endif

--- a/test/unit/minunit.h
+++ b/test/unit/minunit.h
@@ -19,17 +19,16 @@ static int assertionsFailed = 0;
  *
  * @param test an expression that evaluates to a truthy or falsy value.
  */
-#define ASSERT(test)                         \
-    do {                                     \
-        assertionsRun++;                     \
-        if (!(test)) {                       \
-            assertionsFailed++;              \
-            printf(KRED                      \
-                   "ERROR in %s\n"           \
-                   "\tfailed: " #test RESET, \
-                   __func__);                \
-            return FAILURE_RETURN_CODE;      \
-        }                                    \
+#define ASSERT(test)                                             \
+    do {                                                         \
+        assertionsRun++;                                         \
+        if (!(test)) {                                           \
+            assertionsFailed++;                                  \
+            printf(KRED                                          \
+                   "ERROR in %s\n\tfailed: " #test "\n\n" RESET, \
+                   __func__);                                    \
+            return FAILURE_RETURN_CODE;                          \
+        }                                                        \
     } while (0)
 
 /**

--- a/test/unit/minunit.h
+++ b/test/unit/minunit.h
@@ -19,14 +19,17 @@ static int assertionsFailed = 0;
  *
  * @param test an expression that evaluates to a truthy or falsy value.
  */
-#define ASSERT(test)                                          \
-    do {                                                      \
-        assertionsRun++;                                      \
-        if (!(test)) {                                        \
-            assertionsFailed++;                               \
-            printf(KRED "ERROR - failed: " #test "\n" RESET); \
-            return FAILURE_RETURN_CODE;                       \
-        }                                                     \
+#define ASSERT(test)                         \
+    do {                                     \
+        assertionsRun++;                     \
+        if (!(test)) {                       \
+            assertionsFailed++;              \
+            printf(KRED                      \
+                   "ERROR in %s\n"           \
+                   "\tfailed: " #test RESET, \
+                   __func__);                \
+            return FAILURE_RETURN_CODE;      \
+        }                                    \
     } while (0)
 
 /**

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -302,9 +302,9 @@ int test_compiler_val_declaration() {
     CompiledCode compiledCode = compile(&compiler);
 
     // Verify bytecode for val declaration
-    ASSERT(compiledCode.bytecodeArray.used == 2);                           // Check if two bytecode instructions are generated
-    ASSERT(compiledCode.bytecodeArray.values[0].type == OP_LOAD_CONSTANT);  // First should be OP_LOAD_CONSTANT
-    ASSERT(compiledCode.bytecodeArray.values[1].type == OP_SET_VAL);        // Second should be OP_SET_VAL
+    ASSERT(compiledCode.bytecodeArray.used == 2);                            // Check if two bytecode instructions are generated
+    ASSERT(compiledCode.bytecodeArray.values[0].type == OP_LOAD_CONSTANT);   // First should be OP_LOAD_CONSTANT
+    ASSERT(compiledCode.bytecodeArray.values[1].type == OP_SET_GLOBAL_VAL);  // Second should be OP_SET_GLOBAL_VAL
 
     // printCompiledCode(compiledCode);
 
@@ -328,10 +328,10 @@ int test_compiler_variable_declaration_and_printing() {
     initCompiler(&compiler, &testSource);
     CompiledCode compiledCode = compile(&compiler);
 
-    ASSERT(compiledCode.bytecodeArray.values[0].type == OP_LOAD_CONSTANT);  // load 42 into stack
-    ASSERT(compiledCode.bytecodeArray.values[1].type == OP_SET_VAL);        // assign top of stack to variable 'x'
-    ASSERT(compiledCode.bytecodeArray.values[2].type == OP_GET_VAL);        // get variable 'x'
-    ASSERT(compiledCode.bytecodeArray.values[3].type == OP_PRINT);          // print top of stack
+    ASSERT(compiledCode.bytecodeArray.values[0].type == OP_LOAD_CONSTANT);   // load 42 into stack
+    ASSERT(compiledCode.bytecodeArray.values[1].type == OP_SET_GLOBAL_VAL);  // assign top of stack to variable 'x'
+    ASSERT(compiledCode.bytecodeArray.values[2].type == OP_GET_GLOBAL_VAL);  // get variable 'x'
+    ASSERT(compiledCode.bytecodeArray.values[3].type == OP_PRINT);           // print top of stack
 
     ASSERT(compiledCode.constantPool.values[0].type == CONST_TYPE_DOUBLE);  // 42
     ASSERT(compiledCode.constantPool.values[0].as.number == 42);

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -779,7 +779,7 @@ int test_compiler_single_block_statement_with_locals() {
     return SUCCESS_RETURN_CODE;
 }
 
-int test_nested_blocks_with_global_and_local_vars() {
+int test_compiler_nested_blocks_with_global_and_local_vars() {
     Compiler compiler;
 
     /*
@@ -817,7 +817,7 @@ int test_nested_blocks_with_global_and_local_vars() {
     CompiledCode compiledCode = compile(&compiler);
 
     Bytecode expectedBytecode[] = {
-        {.type = OP_LOAD_CONSTANT},  //
+        {.type = OP_LOAD_CONSTANT},
         {.type = OP_SET_GLOBAL_VAL},
         {.type = OP_GET_GLOBAL_VAL},
         {.type = OP_PRINT},

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -715,8 +715,9 @@ int test_compiler_stack_height_expression_and_val() {
     ASSERT(compiler.currentStackHeight == 0);  // Should start at zero
     CompiledCode compiledCode = compile(&compiler);
 
-    // The expression and print statements shouldn't add to the height. The val declaration should add 1.
-    ASSERT(compiler.currentStackHeight == 1);
+    // The expression and print statements shouldn't add to the height.
+    // The val declaration also shouldn't add anything because it's a global variable.
+    ASSERT(compiler.currentStackHeight == 0);
 
     // Clean up
     FREE_ARRAY(compiledCode.bytecodeArray);

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -233,7 +233,7 @@ int test_compiler() {
 
     initCompiler(&compiler, &testSource);
     CompiledCode compiledCode = compile(&compiler);
-    printCompiledCode(compiledCode);
+    // printCompiledCode(compiledCode);
 
     // Expected bytecode
     Bytecode expectedBytecode[] = {
@@ -279,7 +279,7 @@ int test_compiler_print() {
     ASSERT(compiledCode.bytecodeArray.values[1].type == OP_PRINT);          // Second should be OP_PRINT
 
     // Optionally, print the bytecode for visual verification
-    printCompiledCode(compiledCode);
+    // printCompiledCode(compiledCode);
 
     // Clean up
     FREE_ARRAY(compiledCode.bytecodeArray);
@@ -306,7 +306,7 @@ int test_compiler_val_declaration() {
     ASSERT(compiledCode.bytecodeArray.values[0].type == OP_LOAD_CONSTANT);  // First should be OP_LOAD_CONSTANT
     ASSERT(compiledCode.bytecodeArray.values[1].type == OP_SET_VAL);        // Second should be OP_SET_VAL
 
-    printCompiledCode(compiledCode);
+    // printCompiledCode(compiledCode);
 
     FREE_ARRAY(compiledCode.bytecodeArray);
     FREE_ARRAY(compiledCode.constantPool);

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -245,10 +245,10 @@ int test_compiler() {
 
     // Compared the actual and expected
     ASSERT(compareTypesInBytecodeArrays(expectedBytecodeArray, compiledCode.bytecodeArray));
-    ASSERT(compiledCode.constantPool.values[0].as.number == 5);            // 5 is in slot 0 of the pool
-    ASSERT(compiledCode.bytecodeArray.values[0].maybeConstantIndex == 0);  // first instruction loads slot 0
+    ASSERT(compiledCode.constantPool.values[0].as.number == 5);       // 5 is in slot 0 of the pool
+    ASSERT(compiledCode.bytecodeArray.values[0].maybeOperand1 == 0);  // first instruction loads slot 0
     ASSERT(compiledCode.constantPool.values[1].as.number == 7);
-    ASSERT(compiledCode.bytecodeArray.values[1].maybeConstantIndex == 1);
+    ASSERT(compiledCode.bytecodeArray.values[1].maybeOperand1 == 1);
 
     // Clean up
     FREE_ARRAY(compiledCode.bytecodeArray);

--- a/test/unit/src/parser_test.c
+++ b/test/unit/src/parser_test.c
@@ -619,3 +619,36 @@ int test_parser_string_literal() {
 
     return SUCCESS_RETURN_CODE;
 }
+
+int test_parser_block_statement() {
+    TokenType types[] = {TOKEN_LEFT_CURLY, TOKEN_VAL, TOKEN_IDENTIFIER, TOKEN_EQUAL, TOKEN_NUMBER, TOKEN_SEMICOLON, TOKEN_PRINT, TOKEN_IDENTIFIER, TOKEN_SEMICOLON, TOKEN_RIGHT_CURLY, TOKEN_EOF};
+    TokenArray tokens = createTokenArray(types, 11);
+
+    ASTParser parser;
+    initASTParser(&parser, tokens);
+    Source* source = parseAST(&parser);
+
+    ASSERT(source->numberOfStatements == 1);
+    ASSERT(source->rootStatements[0]->type == BLOCK_STATEMENT);
+    ASSERT(source->rootStatements[0]->as.blockStatement->statementArray.used == 2);  // val declaration and print statement
+
+    // Assert that the first statement is a val declaration
+    Statement* firstStmt = source->rootStatements[0]->as.blockStatement->statementArray.values[0];
+    ASSERT(firstStmt->type == VAL_DECLARATION_STATEMENT);
+    ValDeclarationStatement* valDeclStmt = firstStmt->as.valDeclarationStatement;
+    ASSERT(strcmp(valDeclStmt->identifier->token.start, "x") == 0);  // Assuming "x" is the identifier used
+    ASSERT(valDeclStmt->expression->type == PRIMARY_EXPRESSION);
+    NumberLiteral* numberLiteral = valDeclStmt->expression->as.primaryExpression->literal->as.numberLiteral;
+    ASSERT(strcmp(numberLiteral->token.start, "10") == 0);  // Assuming "10" is the number used
+
+    // Assert that the second statement is a print statement
+    Statement* secondStmt = source->rootStatements[0]->as.blockStatement->statementArray.values[1];
+    ASSERT(secondStmt->type == PRINT_STATEMENT);
+    PrintStatement* printStmt = secondStmt->as.printStatement;
+    ASSERT(printStmt->expression->type == PRIMARY_EXPRESSION);
+    IdentifierLiteral* identifierLiteral = printStmt->expression->as.primaryExpression->literal->as.identifierLiteral;
+    ASSERT(strcmp(identifierLiteral->token.start, "x") == 0);  // Assuming "x" is the identifier used
+
+    freeSource(source);
+    return SUCCESS_RETURN_CODE;
+}

--- a/test/unit/src/parser_test.c
+++ b/test/unit/src/parser_test.c
@@ -636,18 +636,13 @@ int test_parser_block_statement() {
     Statement* firstStmt = source->rootStatements[0]->as.blockStatement->statementArray.values[0];
     ASSERT(firstStmt->type == VAL_DECLARATION_STATEMENT);
     ValDeclarationStatement* valDeclStmt = firstStmt->as.valDeclarationStatement;
-    ASSERT(strcmp(valDeclStmt->identifier->token.start, "x") == 0);  // Assuming "x" is the identifier used
     ASSERT(valDeclStmt->expression->type == PRIMARY_EXPRESSION);
-    NumberLiteral* numberLiteral = valDeclStmt->expression->as.primaryExpression->literal->as.numberLiteral;
-    ASSERT(strcmp(numberLiteral->token.start, "10") == 0);  // Assuming "10" is the number used
 
     // Assert that the second statement is a print statement
     Statement* secondStmt = source->rootStatements[0]->as.blockStatement->statementArray.values[1];
     ASSERT(secondStmt->type == PRINT_STATEMENT);
     PrintStatement* printStmt = secondStmt->as.printStatement;
     ASSERT(printStmt->expression->type == PRIMARY_EXPRESSION);
-    IdentifierLiteral* identifierLiteral = printStmt->expression->as.primaryExpression->literal->as.identifierLiteral;
-    ASSERT(strcmp(identifierLiteral->token.start, "x") == 0);  // Assuming "x" is the identifier used
 
     freeSource(source);
     return SUCCESS_RETURN_CODE;

--- a/test/unit/src/parser_test.c
+++ b/test/unit/src/parser_test.c
@@ -52,7 +52,7 @@ int test_parser_simple_expression() {
     // Parse the expression
     Source* source = parseAST(&parser);
 
-    printAST(source);
+    // printAST(source);
 
     // Assertions to check the structure of the parsed AST
     ASSERT(source->numberOfStatements == 1);
@@ -118,7 +118,7 @@ int test_parser_logical_or_expression() {
 
     ASTParser parser;
     Source* source = parseASTFromTokens(&parser, &tokens);
-    printAST(source);
+    // printAST(source);
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -163,7 +163,7 @@ int test_parser_logical_and_expression() {
     ASTParser parser;
     initASTParser(&parser, tokens);
     Source* source = parseAST(&parser);
-    printAST(source);
+    // printAST(source);
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -206,7 +206,7 @@ int test_parser_equality_expression() {
     ASTParser parser;
     initASTParser(&parser, tokens);
     Source* source = parseAST(&parser);
-    printAST(source);
+    // printAST(source);
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -248,7 +248,7 @@ int test_parser_comparison_expression() {
     ASTParser parser;
     initASTParser(&parser, tokens);
     Source* source = parseAST(&parser);
-    printAST(source);
+    // printAST(source);
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -290,7 +290,7 @@ int test_parser_multiplicative_expression() {
     ASTParser parser;
     initASTParser(&parser, tokens);
     Source* source = parseAST(&parser);
-    printAST(source);
+    // printAST(source);
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -331,7 +331,7 @@ int test_parser_unary_expression() {
     ASTParser parser;
     initASTParser(&parser, tokens);
     Source* source = parseAST(&parser);
-    printAST(source);
+    // printAST(source);
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -366,7 +366,7 @@ int test_parser_boolean_literal() {
     ASTParser parser;
     initASTParser(&parser, tokens);
     Source* source = parseAST(&parser);
-    printAST(source);
+    // printAST(source);
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -419,7 +419,7 @@ int test_parser_complex_expression() {
     ASTParser parser;
     initASTParser(&parser, tokens);
     Source* source = parseAST(&parser);
-    printAST(source);
+    // printAST(source);
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -511,7 +511,7 @@ int test_parser_nested_parentheses_expression() {
 
     Source* source = parseAST(&parser);
     ASSERT(source->numberOfStatements == 1);  // Ensure one statement was parsed
-    printAST(source);
+    // printAST(source);
 
     Statement* statement = source->rootStatements[0];
     ASSERT(statement->type == EXPRESSION_STATEMENT);  // Ensure the statement is an expression

--- a/test/unit/src/scanner_test.c
+++ b/test/unit/src/scanner_test.c
@@ -13,7 +13,7 @@ int test_scanner() {
 
     initScanner(&scanner, sourceCode);
     TokenArray tokens = scanTokens(&scanner);
-    printTokenList(tokens);
+    // printTokenList(tokens);
 
     ASSERT_WITH_MESSAGE(tokens.used == expectedTokensLength, printf("ERROR - %zu tokens were found, but %d were expected.\n", tokens.used, expectedTokensLength));
 

--- a/test/unit/src/vm_test.c
+++ b/test/unit/src/vm_test.c
@@ -124,8 +124,8 @@ int test_vm_set_and_get_global() {
     size_t numberValueIndex = 1;
 
     INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, numberValueIndex), Bytecode);
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_SET_VAL, valNameIndex), Bytecode);
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_GET_VAL, valNameIndex), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_SET_GLOBAL_VAL, valNameIndex), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_GET_GLOBAL_VAL, valNameIndex), Bytecode);
 
     // Initialize VM with the bytecode
     VM vm;

--- a/test/unit/src/vm_test.c
+++ b/test/unit/src/vm_test.c
@@ -404,10 +404,10 @@ int test_vm_print_string_literal() {
     INIT_ARRAY(code.bytecodeArray, Bytecode);
     INIT_ARRAY(code.constantPool, Constant);
 
-    // Assuming you have a function to add a string to the constant pool and return its index
-    INSERT_ARRAY(code.constantPool, STRING_CONST("Hello, World!\0"), Constant);  // Index 0
+    // Add the string to the constant pool
+    INSERT_ARRAY(code.constantPool, STRING_CONST("Hello, World!"), Constant);  // Index 0
 
-    // Assuming you have specific bytecode operations for loading a constant and printing
+    // Bytecode operations for loading a constant and printing
     INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
     INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_PRINT), Bytecode);
 
@@ -415,19 +415,7 @@ int test_vm_print_string_literal() {
     VM vm;
     initVM(&vm, code);
 
-    // Redirect stdout to a buffer to capture the output
-    char buffer[1024];
-    freopen("/dev/null", "a", stdout);  // Prevent actual printing to stdout
-    setbuf(stdout, buffer);
-
-    // Run the VM
-    run(&vm);
-
-    // Restore stdout
-    freopen("/dev/tty", "a", stdout);
-
-    // Check if the buffer contains the expected string
-    ASSERT(strcmp(buffer, "Hello, World!") == 0);
+    CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "Hello, World!\n") == 0); });
 
     // Cleanup
     FREE_ARRAY(code.bytecodeArray);

--- a/test/unit/src/vm_test.c
+++ b/test/unit/src/vm_test.c
@@ -35,8 +35,8 @@ int test_vm_addition() {
     // Create a simple bytecode program: 1 + 2
     INSERT_ARRAY(code.constantPool, DOUBLE_CONST(1.0), Constant);  // put Constant in index 0
     INSERT_ARRAY(code.constantPool, DOUBLE_CONST(2.0), Constant);  // put Constant in index 1
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 1), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 1), Bytecode);
     INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_BINARY_ADD), Bytecode);
 
     // Initialize VM with the bytecode
@@ -72,7 +72,7 @@ int test_vm_print() {
     INSERT_ARRAY(code.constantPool, numberToPrint, Constant);
     size_t indexOfNumberToPrintInPool = 0;
 
-    Bytecode constantBytecode = BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, indexOfNumberToPrintInPool);
+    Bytecode constantBytecode = BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, indexOfNumberToPrintInPool);
     INSERT_ARRAY(code.bytecodeArray, constantBytecode, Bytecode);
 
     Bytecode printBytecode = BYTECODE(OP_PRINT);
@@ -123,9 +123,9 @@ int test_vm_set_and_get_global() {
     INSERT_ARRAY(code.constantPool, numberValue, Constant);
     size_t numberValueIndex = 1;
 
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, numberValueIndex), Bytecode);
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_SET_VAL, valNameIndex), Bytecode);
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_GET_VAL, valNameIndex), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, numberValueIndex), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_SET_VAL, valNameIndex), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_GET_VAL, valNameIndex), Bytecode);
 
     // Initialize VM with the bytecode
     VM vm;
@@ -155,13 +155,13 @@ int test_vm_binary_equal() {
 
     // Test case: 1 == 1; should push true
     INSERT_ARRAY(code.constantPool, DOUBLE_CONST(1.0), Constant);
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
     INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_BINARY_EQUAL), Bytecode);
 
     // Test case: 1 != 1; should push false
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
     INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_BINARY_NOT_EQUAL), Bytecode);
 
     VM vm;
@@ -194,23 +194,23 @@ int test_vm_comparison_operations() {
     INSERT_ARRAY(code.constantPool, DOUBLE_CONST(2.0), Constant);  // Index 1
 
     // Test case: 1 < 2; should push true
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 1), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 1), Bytecode);
     INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_BINARY_LT), Bytecode);
 
     // Test case: 1 <= 2; should push true
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 1), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 1), Bytecode);
     INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_BINARY_LTE), Bytecode);
 
     // Test case: 2 > 1; should push true
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 1), Bytecode);
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 1), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
     INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_BINARY_GT), Bytecode);
 
     // Test case: 2 >= 1; should push true
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 1), Bytecode);
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 1), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
     INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_BINARY_GTE), Bytecode);
 
     VM vm;
@@ -247,13 +247,13 @@ int test_vm_logical_operations() {
     INSERT_ARRAY(code.constantPool, DOUBLE_CONST(0.0), Constant);  // Index 1 as false
 
     // Test case: true && false; should push false
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);  // true
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 1), Bytecode);  // false
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);  // true
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 1), Bytecode);  // false
     INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_BINARY_LOGICAL_AND), Bytecode);
 
     // Test case: false || true; should push true
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 1), Bytecode);  // false
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);  // true
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 1), Bytecode);  // false
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);  // true
     INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_BINARY_LOGICAL_OR), Bytecode);
 
     VM vm;
@@ -284,9 +284,9 @@ int test_vm_boolean_truthiness() {
     // Preparing constants
     INSERT_ARRAY(code.constantPool, DOUBLE_CONST(0.0), Constant);  // Index 0
 
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);  // Pushes 0.0
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_FALSE), Bytecode);                        // Pushes false
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_BINARY_LOGICAL_OR), Bytecode);            // Should evaluate to false
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);  // Pushes 0.0
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_FALSE), Bytecode);                       // Pushes false
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_BINARY_LOGICAL_OR), Bytecode);           // Should evaluate to false
 
     VM vm;
     initVM(&vm, code);
@@ -313,7 +313,7 @@ int test_vm_unary_negation() {
     INSERT_ARRAY(code.constantPool, DOUBLE_CONST(5.0), Constant);  // Index 0, value 5.0
 
     // Load constant onto stack
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
     INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_UNARY_NEGATE), Bytecode);
 
     // Initialize VM and run the code
@@ -382,7 +382,7 @@ int test_vm_print_string_literal() {
     INSERT_ARRAY(code.constantPool, STRING_CONST("Hello, World!\0"), Constant);  // Index 0
 
     // Assuming you have specific bytecode operations for loading a constant and printing
-    INSERT_ARRAY(code.bytecodeArray, BYTECODE_CONSTANT_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
     INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_PRINT), Bytecode);
 
     // Initialize VM with the bytecode

--- a/test/unit/src/vm_test.c
+++ b/test/unit/src/vm_test.c
@@ -98,7 +98,7 @@ int test_vm_print() {
     // Assertions
     // Check if the buffer contains the expected output
     char expectedOutput[128];
-    sprintf(expectedOutput, "%f", numberToPrint.as.number);
+    sprintf(expectedOutput, "%f\n", numberToPrint.as.number);
     ASSERT(strcmp(buffer, expectedOutput) == 0);
 
     // Clean up


### PR DESCRIPTION
### Summary

Add support for block statements, scoping, and local variables.
- Local variables live in the stack and have fast access.
- Locals and globals cannot be redefined, but a local can shadow a global.

#### Stack effect tracking and fast local variables
We now have a `tempStack` in the Compiler, which predicts what the VM's stack will look like. In the compiler phase, we know the exact stack effect of every instruction, so it's possible to determine in the compiler at what height the VM stack will be at any point in a function.

With this new stack prediction knowledge in hand, we can add "fast" local variables (similar to [Python's `_FAST` instructions](https://stackoverflow.com/questions/74998947/whats-pythons-load-fast-bytecode-instruction-fast-at)). Fast local variables reference locals that are already in the stack, so no hashing is needed.

For example, 
```
{ 
  val a = 2;    // Puts "2" in the stack and leaves it there
  print a;       // The compiler knows that 'a' will be in slot `0` of the VM, so the VM just reads slot `0` of the stack here.
} 
// Once the block is done, all the values added to the stack in the block are popped.
```

So, the VM doens't have / doesn't need to know the name of local variables. That's handled 

#### Example program with blocks and locals. 
Users can now run programs such as:
```
val g = 100;
print g;
{
    print g;
    val x = 10;
    print x;
    {
        val g = 20;
        print g;
        val y = 30;
        print y;
    }
}
```

### Tests
Added parser, compiler, and VM tests for blocks and locals.

I also tested some scenarios locally:

```
{print a;}
Error: identifier 'a' referenced before declaration.
```
```
val a = 2;
val a = 2;
Error: val "a" is already declared. Redeclaration is not permitted.
```
```
{val a = 2; val a = 2;}
Error: val "a" is already declared locally. Redeclaration is not permitted.
```
```
val a = 2;
{val a = 2;}
// No error
``` 