### PR TITLE
Allow if statement branches to use any statement instead of just block statements

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -492,18 +492,18 @@ static Statement* blockStatement(ASTParser* parser) {
  */
 static Statement* selectionStatement(ASTParser* parser) {
     consume(parser, TOKEN_IF, "Invalid State: Expected \"if\" in if statement.");
-    consume(parser, TOKEN_LEFT_PAREN, "Expected left parenthesis, \"(\", before the condition expression of an if-statement.");
+    // consume(parser, TOKEN_LEFT_PAREN, "Expected left parenthesis, \"(\", before the condition expression of an if-statement.");
     Expression* conditionExpression = expression(parser);
-    consume(parser, TOKEN_RIGHT_PAREN, "Expected right parenthesis, \")\", after the condition expression of an if-statement.");
+    // consume(parser, TOKEN_RIGHT_PAREN, "Expected right parenthesis, \")\", after the condition expression of an if-statement.");
 
-    Statement* trueStatement = blockStatement(parser);
+    Statement* trueStatement = statement(parser);
 
     SelectionStatement* selectionStatement = allocateASTNode(SelectionStatement);
     selectionStatement->conditionExpression = conditionExpression;
     selectionStatement->trueStatement = trueStatement;
 
     if (match(parser, TOKEN_ELSE)) {
-        Statement* falseStatement = blockStatement(parser);
+        Statement* falseStatement = statement(parser);
         selectionStatement->falseStatement = falseStatement;
     } else {
         selectionStatement->falseStatement = NULL;

--- a/test/solscript/if_statements/no_brackes.sol
+++ b/test/solscript/if_statements/no_brackes.sol
@@ -1,0 +1,50 @@
+// No else branch and no blocks
+if (true) print "Should print";
+if (false) print "Should NOT print";
+
+// Neither if nor else use blocks
+if (true)
+    print "Should print";
+else
+    print "Should NOT print";
+
+if (false)
+    print "Should NOT print";
+else
+    print "Should print";
+
+
+// One of if or else use blocks
+if (false) {
+    print "Should NOT print";
+}
+else
+    print "Should print";
+
+if (false)
+    print "Should NOT print";
+else {
+    print "Should print";
+}
+
+
+// Both if and else use blocks
+val a = 20;
+if (a > 15) {
+    print "Should print";
+} else {
+    print "Should NOT print";
+}
+
+// Multiple statements in block
+if (true) {
+    print "Should print";
+    print "Should print";
+}
+if (true)
+    print "Should print";
+    print "Should print";
+
+if (false)
+    print "Should NOT print";
+    print "Should print";


### PR DESCRIPTION
### Summary
This PR makes it so that if statement branches can be any `Statement`, not just block statements. Users can now use if statements without curly braces.

If statements are now compliant with the grammar specification.
```
selection-statement:
  "if" "(" expression ")" statement ( "else" statement )?
```


#### Example
```
if (true)
    print "Should print";
else
    print "Should NOT print";
```


### Tests
Added tests covering different cases and manually confirmed results are correct. See  
`test/solscript/if_statements/no_brackes.sol`.

All existing unit tests still pass.