### PR TITLE
Improve test framework - only print test output if the test fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ The following features are necessary a proper v1.0 release, in rough order:
  - [X] Add [_FAST](https://stackoverflow.com/questions/74998947/whats-pythons-load-fast-bytecode-instruction-fast-at) local variables
  - [X] Implement selection statement (`if`s)
  - [ ] Implement the rest of the parser for the whole syntax grammar
- - [ ] Add conditional debugging/logging for tests that fail
+ - [X] Add conditional debugging/logging for tests that fail
  - [ ] Implement functions and returns
  - [ ] Implement assignment statements
  - [ ] Add CLI argument to enable or disable debugging logs in the REPL.

--- a/src/util/colors.h
+++ b/src/util/colors.h
@@ -12,4 +12,7 @@
 #define KGRY "\x1B[37m"   // Grey
 #define KDGRY "\x1B[90m"  // Dark grey
 
+#define KBOLD "\e[1m"  // Bold
+#define KBOFF "\e[m"   // End bold
+
 #endif

--- a/test/unit/minunit.h
+++ b/test/unit/minunit.h
@@ -2,8 +2,13 @@
 #ifndef minunit_h
 #define minunit_h
 
+#include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "util/colors.h"
 
@@ -20,16 +25,15 @@ static int assertionsFailed = 0;
  *
  * @param test an expression that evaluates to a truthy or falsy value.
  */
-#define ASSERT(test)                                             \
-    do {                                                         \
-        assertionsRun++;                                         \
-        if (!(test)) {                                           \
-            assertionsFailed++;                                  \
-            printf(KRED                                          \
-                   "ERROR in %s\n\tfailed: " #test "\n\n" RESET, \
-                   __func__);                                    \
-            return FAILURE_RETURN_CODE;                          \
-        }                                                        \
+#define ASSERT(test)                             \
+    do {                                         \
+        assertionsRun++;                         \
+        if (!(test)) {                           \
+            assertionsFailed++;                  \
+            printf(KRED                          \
+                   "Failed: " #test "\n" RESET); \
+            return FAILURE_RETURN_CODE;          \
+        }                                        \
     } while (0)
 
 /**
@@ -53,7 +57,78 @@ static int assertionsFailed = 0;
  *
  * @param test a function of return type `int`.
  */
-#define RUN_TEST(test)               \
+
+// Buffer size for capturing test outputs. Adjust as necessary.
+#define OUTPUT_BUFFER_SIZE 1024 * 1024
+
+/**
+ * Execute a tests suite and keep track of successes and failures.
+ * Anything the test prints to std out will be buffered and only printed if
+ * the test fails.
+ *
+ * (This macro can be significantly optimized; it doesn't even need to be a macro.)
+ *
+ * @param test a function of return type `int`.
+ */
+#define RUN_TEST(test)                                                \
+    do {                                                              \
+        fflush(stdout);                                               \
+        int originalStdout = dup(STDOUT_FILENO);                      \
+                                                                      \
+        /* Create a temporary file for capturing output */            \
+        char tempFileName[] = "/tmp/test_outputXXXXXX";               \
+        int tempFileDescriptor = mkstemp(tempFileName);               \
+        if (tempFileDescriptor == -1) {                               \
+            perror("Could not create temp file for test output");     \
+            exit(EXIT_FAILURE);                                       \
+        }                                                             \
+        FILE* tempFile = fdopen(tempFileDescriptor, "w+");            \
+        if (!tempFile) {                                              \
+            perror("Failed to open temp file for test output");       \
+            close(tempFileDescriptor);                                \
+            exit(EXIT_FAILURE);                                       \
+        }                                                             \
+                                                                      \
+        /* Redirect stdout to the temporary file */                   \
+        dup2(tempFileDescriptor, STDOUT_FILENO);                      \
+                                                                      \
+        /* Run the test */                                            \
+        int testResult = test();                                      \
+                                                                      \
+        /* Flush and redirect stdout back to its original */          \
+        fflush(stdout);                                               \
+        dup2(originalStdout, STDOUT_FILENO);                          \
+        close(originalStdout);                                        \
+                                                                      \
+        if (testResult) {                                             \
+            /* Seek to the beginning of the temp file */              \
+            rewind(tempFile);                                         \
+                                                                      \
+            printf(KBOLD KRED "%s\n\n" RESET KBOFF, #test);           \
+            /* Read and print the contents of the temp file */        \
+            char buffer[1024];                                        \
+            while (fgets(buffer, sizeof(buffer), tempFile) != NULL) { \
+                printf("%s", buffer);                                 \
+            }                                                         \
+            printf(KDGRY "------------------------------\n" RESET);   \
+                                                                      \
+            testsFailed++;                                            \
+        }                                                             \
+                                                                      \
+        /* Clean up */                                                \
+        fclose(tempFile);                                             \
+        unlink(tempFileName);                                         \
+                                                                      \
+        testsRun++;                                                   \
+    } while (0)
+
+/**
+ * @deprecated
+ * Execute a tests suite and keep track of successes and failures.
+ *
+ * @param test a function of return type `int`.
+ */
+#define RUN_TEST_SIMPLE(test)        \
     do {                             \
         int testReturnCode = test(); \
         testsRun++;                  \
@@ -76,7 +151,7 @@ static int assertionsFailed = 0;
         printf("Assertions run: %d, failed: %d.\n", assertionsRun, assertionsFailed);     \
         printf("Tests run: %d, failed: %d. (%.5fs)\n", testsRun, testsFailed, timeTaken); \
         if (testsFailed) {                                                                \
-            printf(KRED "FAILED\n" RESET);                                                \
+            printf(KBOLD KRED "FAILED\n" RESET KBOFF);                                    \
         } else {                                                                          \
             printf(KGRN "PASSED\n" RESET);                                                \
         }                                                                                 \

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -235,14 +235,20 @@ static int compareTypesInBytecodeArrays(BytecodeArray expected, BytecodeArray ac
     return 1;
 }
 
+// Macro to initialize compiler, compile AST, and print the compiled bytecode
+// Assumes the source is named `testSource`; creates a variable called `compiledCode`.
+#define COMPILE_TEST_SOURCE                         \
+    Compiler compiler;                              \
+    initCompiler(&compiler, &testSource);           \
+    CompiledCode compiledCode = compile(&compiler); \
+    printCompiledCode(compiledCode);
+
 // -------------------------------------------------------------------------
 // --------------------------------- Tests ---------------------------------
 // -------------------------------------------------------------------------
 
 // Test basic arithmetic expression
 int test_compiler() {
-    Compiler compiler;
-
     Source testSource = {
         .rootStatements = {
             EXPRESSION_STATEMENT(
@@ -253,9 +259,7 @@ int test_compiler() {
         .numberOfStatements = 1,
     };
 
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
-    // printCompiledCode(compiledCode);
+    COMPILE_TEST_SOURCE
 
     // Expected bytecode
     Bytecode expectedBytecode[] = {
@@ -281,8 +285,6 @@ int test_compiler() {
 }
 
 int test_compiler_print() {
-    Compiler compiler;
-
     // Set up a source structure with a print statement
     Source testSource = {
         .rootStatements = {
@@ -290,18 +292,13 @@ int test_compiler_print() {
         .numberOfStatements = 1,
     };
 
-    // Initialize and run the compiler
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
     // Verify the bytecode
     // Assuming the bytecode for a print statement is OP_PRINT followed by the value to print
     ASSERT(compiledCode.bytecodeArray.used == 2);                           // Check if two bytecode instructions are generated
     ASSERT(compiledCode.bytecodeArray.values[0].type == OP_LOAD_CONSTANT);  // First should be OP_CONSTANT
     ASSERT(compiledCode.bytecodeArray.values[1].type == OP_PRINT);          // Second should be OP_PRINT
-
-    // Optionally, print the bytecode for visual verification
-    // printCompiledCode(compiledCode);
 
     // Clean up
     FREE_ARRAY(compiledCode.bytecodeArray);
@@ -311,8 +308,6 @@ int test_compiler_print() {
 }
 
 int test_compiler_val_declaration() {
-    Compiler compiler;
-
     // Setup a source structure with a val declaration statement
     Source testSource = {
         .rootStatements = {
@@ -320,8 +315,7 @@ int test_compiler_val_declaration() {
         .numberOfStatements = 1,
     };
 
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
     // Verify bytecode for val declaration
     ASSERT(compiledCode.bytecodeArray.used == 2);                            // Check if two bytecode instructions are generated
@@ -346,9 +340,7 @@ int test_compiler_variable_declaration_and_printing() {
         .numberOfStatements = 2,
     };
 
-    Compiler compiler;
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
     ASSERT(compiledCode.bytecodeArray.values[0].type == OP_LOAD_CONSTANT);   // load 42 into stack
     ASSERT(compiledCode.bytecodeArray.values[1].type == OP_SET_GLOBAL_VAL);  // assign top of stack to variable 'x'
@@ -366,7 +358,7 @@ int test_compiler_variable_declaration_and_printing() {
 }
 
 int test_add_constant_to_pool_no_duplicates() {
-    Source source = (Source){
+    Source testSource = (Source){
         .rootStatements = {
             VAL_DECLARATION_STATEMENT("x", PRIMARY_EXPRESSION(NUMBER_LITERAL("42"))),
             PRINT_STATEMENT(PRIMARY_EXPRESSION(IDENTIFIER_LITERAL("x"))),
@@ -374,9 +366,7 @@ int test_add_constant_to_pool_no_duplicates() {
         .numberOfStatements = 3,
     };
 
-    Compiler compiler;
-    initCompiler(&compiler, &source);
-    CompiledCode compiledCode = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
     // Assert the constants were not added twice; there should be one for '42', one for 'x', one for 'y'.
     ASSERT(compiledCode.constantPool.used == 3);
@@ -389,8 +379,6 @@ int test_add_constant_to_pool_no_duplicates() {
 }
 
 int test_compiler_binary_equal() {
-    Compiler compiler;
-
     // Setup source with an equality expression
     Source testSource = {
         .rootStatements = {
@@ -402,8 +390,7 @@ int test_compiler_binary_equal() {
         .numberOfStatements = 1,
     };
 
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
     // Expected bytecode for '5 == 5'
     Bytecode expectedBytecode[] = {
@@ -425,8 +412,6 @@ int test_compiler_binary_equal() {
 }
 
 int test_compiler_binary_not_equal() {
-    Compiler compiler;
-
     // Setup source with a not equal expression
     Source testSource = {
         .rootStatements = {
@@ -438,8 +423,7 @@ int test_compiler_binary_not_equal() {
         .numberOfStatements = 1,
     };
 
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
     // Expected bytecode for '5 != 7'
     Bytecode expectedBytecode[] = {
@@ -461,8 +445,6 @@ int test_compiler_binary_not_equal() {
 }
 
 int test_compiler_comparison_operations() {
-    Compiler compiler;
-
     // Setup source with multiple comparison expressions
     Source testSource = {
         .rootStatements = {
@@ -493,8 +475,7 @@ int test_compiler_comparison_operations() {
         .numberOfStatements = 4,
     };
 
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
     // Expected bytecode for the comparison expressions
     Bytecode expectedBytecode[] = {
@@ -532,8 +513,6 @@ int test_compiler_comparison_operations() {
 }
 
 int test_compiler_logical_and_or_operations() {
-    Compiler compiler;
-
     // Setup source with logical AND and OR expressions
     Source testSource = {
         .rootStatements = {
@@ -551,8 +530,7 @@ int test_compiler_logical_and_or_operations() {
         .numberOfStatements = 2,
     };
 
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
     // Expected bytecode for the logical AND and OR expressions
     Bytecode expectedBytecode[] = {
@@ -580,8 +558,6 @@ int test_compiler_logical_and_or_operations() {
 }
 
 int test_compiler_multiplicative_expressions() {
-    Compiler compiler;
-
     // Setup source with multiplicative expressions
     Source testSource = {
         .rootStatements = {
@@ -600,8 +576,7 @@ int test_compiler_multiplicative_expressions() {
         .numberOfStatements = 2,
     };
 
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
     // Expected bytecode for the multiplicative expressions
     Bytecode expectedBytecode[] = {
@@ -634,8 +609,6 @@ int test_compiler_multiplicative_expressions() {
 }
 
 int test_compiler_unary_expressions() {
-    Compiler compiler;
-
     // Construct an AST for the expressions: -42 and !true
     Source testSource = {
         .rootStatements = {
@@ -648,8 +621,7 @@ int test_compiler_unary_expressions() {
         .numberOfStatements = 2,
     };
 
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
     // Expected bytecode: Load constant 42, apply unary negation, push true, apply logical NOT
     Bytecode expectedBytecode[] = {
@@ -673,29 +645,24 @@ int test_compiler_unary_expressions() {
 }
 
 int test_compiler_boolean_literal() {
-    Compiler compiler;
-
     Source testSource = (Source){
         .rootStatements = {
             EXPRESSION_STATEMENT(PRIMARY_EXPRESSION(BOOLEAN_LITERAL(false)))},
         .numberOfStatements = 1,
     };
 
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCodeFalse = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
-    ASSERT(compiledCodeFalse.bytecodeArray.used == 2);
-    ASSERT(compiledCodeFalse.bytecodeArray.values[0].type == OP_FALSE);
+    ASSERT(compiledCode.bytecodeArray.used == 2);
+    ASSERT(compiledCode.bytecodeArray.values[0].type == OP_FALSE);
 
-    FREE_ARRAY(compiledCodeFalse.bytecodeArray);
-    FREE_ARRAY(compiledCodeFalse.constantPool);
+    FREE_ARRAY(compiledCode.bytecodeArray);
+    FREE_ARRAY(compiledCode.constantPool);
 
     return SUCCESS_RETURN_CODE;
 }
 
 int test_compiler_string_literal() {
-    Compiler compiler;
-
     // Define a source with a string literal
     Source testSource = {
         .rootStatements = {
@@ -705,8 +672,7 @@ int test_compiler_string_literal() {
     };
 
     // Initialize and compile
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
     // Assertions to ensure string literal was correctly recognized, added to the constant pool, and properly loaded
     ASSERT(compiledCode.constantPool.used == 1);                                          // Ensure constant pool has entries
@@ -731,10 +697,7 @@ int test_compiler_stack_height_expression_and_val() {
         .numberOfStatements = 3,
     };
 
-    Compiler compiler;
-    initCompiler(&compiler, &testSource);
-
-    ASSERT(compiler.currentStackHeight == 0);  // Should start at zero
+    COMPILE_TEST_SOURCE
     CompiledCode compiledCode = compile(&compiler);
 
     // The expression and print statements shouldn't add to the height.
@@ -750,8 +713,6 @@ int test_compiler_stack_height_expression_and_val() {
 
 // Test block statements with local variables
 int test_compiler_single_block_statement_with_locals() {
-    Compiler compiler;
-
     // Set up a source structure with a block statement containing local variable declarations and usage
     Source testSource = {
         .rootStatements = {
@@ -762,8 +723,7 @@ int test_compiler_single_block_statement_with_locals() {
         .numberOfStatements = 1,
     };
 
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
     // Define expected bytecode
     Bytecode expectedBytecode[] = {
@@ -790,8 +750,6 @@ int test_compiler_single_block_statement_with_locals() {
 }
 
 int test_compiler_nested_blocks_with_global_and_local_vars() {
-    Compiler compiler;
-
     /*
     val g = 100;
     print g;
@@ -823,8 +781,7 @@ int test_compiler_nested_blocks_with_global_and_local_vars() {
         .numberOfStatements = 3,
     };
 
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
     Bytecode expectedBytecode[] = {
         {.type = OP_LOAD_CONSTANT},
@@ -881,8 +838,6 @@ int test_compiler_nested_blocks_with_global_and_local_vars() {
 }
 
 int test_compiler_if_statement_no_else() {
-    Compiler compiler;
-
     // if (true) { print("Hello, World!") };
     Source testSource = {
         .rootStatements = {
@@ -893,8 +848,7 @@ int test_compiler_if_statement_no_else() {
         .numberOfStatements = 1,
     };
 
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
+    COMPILE_TEST_SOURCE
 
     Bytecode expectedBytecode[] = {
         {.type = OP_TRUE},
@@ -919,8 +873,6 @@ int test_compiler_if_statement_no_else() {
 }
 
 int test_compiler_if_statement_with_else() {
-    Compiler compiler;
-
     // if (false) { print("Hello, World!"); } else { print("Goodbye, World!"); };
     Source testSource = {
         .rootStatements = {
@@ -931,9 +883,7 @@ int test_compiler_if_statement_with_else() {
         .numberOfStatements = 1,
     };
 
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
-    printCompiledCode(compiledCode);
+    COMPILE_TEST_SOURCE
 
     Bytecode expectedBytecode[] = {
         {.type = OP_FALSE},                     // Condition evaluation
@@ -963,8 +913,6 @@ int test_compiler_if_statement_with_else() {
 }
 
 int test_compiler_nested_if_statements() {
-    Compiler compiler;
-
     /*
     if (true) {
         print "true-outer";
@@ -993,9 +941,7 @@ int test_compiler_nested_if_statements() {
         .numberOfStatements = 1,
     };
 
-    initCompiler(&compiler, &testSource);
-    CompiledCode compiledCode = compile(&compiler);
-    printCompiledCode(compiledCode);
+    COMPILE_TEST_SOURCE
 
     // Expected bytecode and constant pool for the nested if statements
     Bytecode expectedBytecode[] = {

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -933,6 +933,7 @@ int test_compiler_if_statement_with_else() {
 
     initCompiler(&compiler, &testSource);
     CompiledCode compiledCode = compile(&compiler);
+    printCompiledCode(compiledCode);
 
     Bytecode expectedBytecode[] = {
         {.type = OP_FALSE},                     // Condition evaluation
@@ -994,6 +995,7 @@ int test_compiler_nested_if_statements() {
 
     initCompiler(&compiler, &testSource);
     CompiledCode compiledCode = compile(&compiler);
+    printCompiledCode(compiledCode);
 
     // Expected bytecode and constant pool for the nested if statements
     Bytecode expectedBytecode[] = {

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -322,8 +322,6 @@ int test_compiler_val_declaration() {
     ASSERT(compiledCode.bytecodeArray.values[0].type == OP_LOAD_CONSTANT);   // First should be OP_LOAD_CONSTANT
     ASSERT(compiledCode.bytecodeArray.values[1].type == OP_SET_GLOBAL_VAL);  // Second should be OP_SET_GLOBAL_VAL
 
-    // printCompiledCode(compiledCode);
-
     FREE_ARRAY(compiledCode.bytecodeArray);
     FREE_ARRAY(compiledCode.constantPool);
 
@@ -698,7 +696,6 @@ int test_compiler_stack_height_expression_and_val() {
     };
 
     COMPILE_TEST_SOURCE
-    CompiledCode compiledCode = compile(&compiler);
 
     // The expression and print statements shouldn't add to the height.
     // The val declaration also shouldn't add anything because it's a global variable.

--- a/test/unit/src/parser_test.c
+++ b/test/unit/src/parser_test.c
@@ -38,6 +38,14 @@ static TokenArray createTokenArrayFromTypesAndLexemes(TokenType types[], const c
     return tokens;
 }
 
+// Macro to initialize a parser, parse the AST from tokens, and print the tree
+// Assumes the source token array is named `tokens`; creates a variable called `source`.
+#define PARSE_TEST_AST                  \
+    ASTParser parser;                   \
+    initASTParser(&parser, tokens);     \
+    Source* source = parseAST(&parser); \
+    printAST(source);
+
 // Test for parsing a val declaration with a simple expression
 int test_parser_simple_expression() {
     // Create a mock token array for the expression "val result = 1 + 2"
@@ -56,14 +64,7 @@ int test_parser_simple_expression() {
         .used = 8,
         .size = 8};
 
-    // Initialize the parser
-    ASTParser parser;
-    initASTParser(&parser, tokens);
-
-    // Parse the expression
-    Source* source = parseAST(&parser);
-
-    // printAST(source);
+    PARSE_TEST_AST
 
     // Assertions to check the structure of the parsed AST
     ASSERT(source->numberOfStatements == 1);
@@ -102,8 +103,7 @@ int test_parser_print_statement() {
     TokenType types[] = {TOKEN_PRINT, TOKEN_NUMBER, TOKEN_PLUS, TOKEN_NUMBER, TOKEN_SEMICOLON, TOKEN_EOF};
     TokenArray tokens = createTokenArray(types, 6);
 
-    ASTParser parser;
-    Source* source = parseASTFromTokens(&parser, &tokens);
+    PARSE_TEST_AST
     ASSERT(source->numberOfStatements == 1);
     ASSERT(source->rootStatements[0]->type == PRINT_STATEMENT);
     ASSERT(source->rootStatements[0]->as.printStatement->expression->type == ADDITIVE_EXPRESSION);
@@ -127,9 +127,7 @@ int test_parser_logical_or_expression() {
         .used = 4,
         .size = 4};
 
-    ASTParser parser;
-    Source* source = parseASTFromTokens(&parser, &tokens);
-    // printAST(source);
+    PARSE_TEST_AST
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -171,10 +169,7 @@ int test_parser_logical_and_expression() {
         .used = 4,
         .size = 4};
 
-    ASTParser parser;
-    initASTParser(&parser, tokens);
-    Source* source = parseAST(&parser);
-    // printAST(source);
+    PARSE_TEST_AST
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -214,10 +209,7 @@ int test_parser_equality_expression() {
         .used = 4,
         .size = 4};
 
-    ASTParser parser;
-    initASTParser(&parser, tokens);
-    Source* source = parseAST(&parser);
-    // printAST(source);
+    PARSE_TEST_AST
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -256,10 +248,7 @@ int test_parser_comparison_expression() {
         .used = 4,
         .size = 4};
 
-    ASTParser parser;
-    initASTParser(&parser, tokens);
-    Source* source = parseAST(&parser);
-    // printAST(source);
+    PARSE_TEST_AST
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -298,10 +287,7 @@ int test_parser_multiplicative_expression() {
         .used = 4,
         .size = 4};
 
-    ASTParser parser;
-    initASTParser(&parser, tokens);
-    Source* source = parseAST(&parser);
-    // printAST(source);
+    PARSE_TEST_AST
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -339,10 +325,7 @@ int test_parser_unary_expression() {
         .used = 3,
         .size = 3};
 
-    ASTParser parser;
-    initASTParser(&parser, tokens);
-    Source* source = parseAST(&parser);
-    // printAST(source);
+    PARSE_TEST_AST
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -374,10 +357,7 @@ int test_parser_boolean_literal() {
         .used = 2,
         .size = 2};
 
-    ASTParser parser;
-    initASTParser(&parser, tokens);
-    Source* source = parseAST(&parser);
-    // printAST(source);
+    PARSE_TEST_AST
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -427,10 +407,7 @@ int test_parser_complex_expression() {
         .used = 21,
         .size = 21};
 
-    ASTParser parser;
-    initASTParser(&parser, tokens);
-    Source* source = parseAST(&parser);
-    // printAST(source);
+    PARSE_TEST_AST
 
     ASSERT(source->numberOfStatements == 1);
 
@@ -517,12 +494,9 @@ int test_parser_nested_parentheses_expression() {
         .used = 11,
         .size = 11};
 
-    ASTParser parser;
-    initASTParser(&parser, tokens);
+    PARSE_TEST_AST
 
-    Source* source = parseAST(&parser);
     ASSERT(source->numberOfStatements == 1);  // Ensure one statement was parsed
-    // printAST(source);
 
     Statement* statement = source->rootStatements[0];
     ASSERT(statement->type == EXPRESSION_STATEMENT);  // Ensure the statement is an expression
@@ -566,9 +540,7 @@ int test_parser_variable_declaration_and_reading() {
         INSERT_ARRAY(tokens, tokensArray[i], Token);
     }
 
-    // Parse the manually created tokens
-    ASTParser parser;
-    Source* source = parseASTFromTokens(&parser, &tokens);
+    PARSE_TEST_AST
 
     // Assertions to validate the AST structure
     ASSERT(source->numberOfStatements == 2);
@@ -609,8 +581,7 @@ int test_parser_string_literal() {
         INSERT_ARRAY(tokens, token, Token);
     }
 
-    ASTParser parser;
-    Source* source = parseASTFromTokens(&parser, &tokens);
+    PARSE_TEST_AST
 
     // Check that the AST correctly represents a string literal expression
     ASSERT(source->numberOfStatements == 1);
@@ -642,9 +613,7 @@ int test_parser_block_statement() {
     TokenArray tokens = createTokenArray(types, sizeof(types) / sizeof(TokenType));
 
     // Initialize the parser and parse the AST from the tokens
-    ASTParser parser;
-    initASTParser(&parser, tokens);
-    Source* source = parseAST(&parser);
+    PARSE_TEST_AST
 
     // Assertions to verify the structure of the parsed AST
     // Expect one statement at the root, which is a block statement
@@ -678,9 +647,8 @@ int test_parser_if_statement_true_branch_only() {
     const char* lexemes[] = {"if", "(", "true", ")", "{", "print", "\"Hello, World!\"", ";", "}", ""};
 
     TokenArray tokens = createTokenArrayFromTypesAndLexemes(types, lexemes, sizeof(types) / sizeof(TokenType));
-    ASTParser parser;
-    initASTParser(&parser, tokens);
-    Source* source = parseAST(&parser);
+
+    PARSE_TEST_AST
 
     ASSERT(source->numberOfStatements == 1);
     ASSERT(source->rootStatements[0]->type == SELECTION_STATEMENT);
@@ -707,9 +675,8 @@ int test_parser_if_statement_with_else_branch() {
     const char* lexemes[] = {"if", "(", "true", ")", "{", "print", "\"Hello, World!\"", ";", "}", "else", "{", "print", "\"Goodbye, World!\"", ";", "}", ""};
 
     TokenArray tokens = createTokenArrayFromTypesAndLexemes(types, lexemes, sizeof(types) / sizeof(TokenType));
-    ASTParser parser;
-    initASTParser(&parser, tokens);
-    Source* source = parseAST(&parser);
+
+    PARSE_TEST_AST
 
     ASSERT(source->numberOfStatements == 1);
     ASSERT(source->rootStatements[0]->type == SELECTION_STATEMENT);

--- a/test/unit/src/vm_test.c
+++ b/test/unit/src/vm_test.c
@@ -4,30 +4,8 @@
 #include <stdlib.h>
 
 #include "../minunit.h"
+#include "../utils.h"
 #include "bytecode.h"
-
-// Macro to facilitate checking that print statements are printing. Uses a temporary file.
-#define BUFFER_SIZE 1024
-#define CAPTURE_PRINT_OUTPUT(executionBlock, assertionsBlock)    \
-    do {                                                         \
-        char buffer[BUFFER_SIZE] = {0};                          \
-        FILE* old_stdout = stdout;                               \
-        FILE* temp_file = tmpfile();                             \
-        if (!temp_file) {                                        \
-            perror("Failed to open temporary file");             \
-            exit(EXIT_FAILURE);                                  \
-        }                                                        \
-        stdout = temp_file;                                      \
-                                                                 \
-        executionBlock                                           \
-                                                                 \
-            fflush(stdout);                                      \
-        stdout = old_stdout;                                     \
-        fseek(temp_file, 0, SEEK_SET);                           \
-        fread(buffer, sizeof(char), BUFFER_SIZE - 1, temp_file); \
-        fclose(temp_file);                                       \
-        assertionsBlock                                          \
-    } while (0)
 
 // Helper function to compare values
 int compareValues(Value a, Value b) {

--- a/test/unit/utils.h
+++ b/test/unit/utils.h
@@ -1,0 +1,34 @@
+#ifndef unit_test_utils_h
+#define unit_test_utils_h
+
+// This file contains utilities to use across unit tests
+
+/**
+ * Macro to capture the std output of a test. It can be used to confirm that a correct values
+ * are being printed, for example.
+ *
+ * Uses a temporary file.
+ */
+#define BUFFER_SIZE 1024
+#define CAPTURE_PRINT_OUTPUT(executionBlock, assertionsBlock)    \
+    do {                                                         \
+        char buffer[BUFFER_SIZE] = {0};                          \
+        FILE* old_stdout = stdout;                               \
+        FILE* temp_file = tmpfile();                             \
+        if (!temp_file) {                                        \
+            perror("Failed to open temporary file");             \
+            exit(EXIT_FAILURE);                                  \
+        }                                                        \
+        stdout = temp_file;                                      \
+                                                                 \
+        executionBlock                                           \
+                                                                 \
+            fflush(stdout);                                      \
+        stdout = old_stdout;                                     \
+        fseek(temp_file, 0, SEEK_SET);                           \
+        fread(buffer, sizeof(char), BUFFER_SIZE - 1, temp_file); \
+        fclose(temp_file);                                       \
+        assertionsBlock                                          \
+    } while (0)
+
+#endif


### PR DESCRIPTION
### Summary

This PR makes it so test output is only printed to the terminal if the test fails.
- This functionality is implemented by creating a temporary file and redirecting stdout to it, then conditionally printing if the test fails.
  - I suspect this can be heavily optimized in the future, e.g. by not opening a new file each time and not using macros.

I also removed a bit of code repetition in the compiler and parser tests.

### Tests 

When no tests fail:
```
% make clean && make test
...
Assertions run: 490, failed: 0.
Tests run: 54, failed: 0. (0.00645s)
PASSED
```

When one test fails
(colours don't show here, but they do work.)
```
% make clean && make test
...
test_compiler_nested_if_statements

Compiled code:
Constant Pool 
 #0   (string) "true-outer"
 #1   (string) "true-inner"
 #2   (string) "false-inner"
 #3   (string) "false-outer"
Bytecode
 0    TRUE
 1    OP_JUMP_IF_FALSE #15
 2    LOAD_CONSTANT #0
 3    PRINT
 4    TRUE
 5    OP_JUMP_IF_FALSE #10
 6    LOAD_CONSTANT #1
 7    PRINT
 8    OP_POPN 0
 9    OP_JUMP #13
 10   LOAD_CONSTANT #2
 11   PRINT
 12   OP_POPN 0
 13   OP_POPN 0
 14   OP_JUMP #18
 15   LOAD_CONSTANT #3
 16   PRINT
 17   OP_POPN 0

Failed: compiledCode.bytecodeArray.values[17].maybeOperand1 == 10
------------------------------

Assertions run: 490, failed: 1.
Tests run: 54, failed: 1. (0.00851s)
FAILED
make: *** [test] Error 1
``` 

When two tests fail
```
% make clean && make test
...
test_compiler_if_statement_with_else

Compiled code:
Constant Pool 
 #0   (string) "Hello, World!"
 #1   (string) "Goodbye, World!"
Bytecode
 0    FALSE
 1    OP_JUMP_IF_FALSE #6
 2    LOAD_CONSTANT #0
 3    PRINT
 4    OP_POPN 0
 5    OP_JUMP #9
 6    LOAD_CONSTANT #1
 7    PRINT
 8    OP_POPN 0

Failed: expectedBytecode[8].maybeOperand1 != compiledCode.bytecodeArray.values[8].maybeOperand1
------------------------------
test_compiler_nested_if_statements

Compiled code:
Constant Pool 
 #0   (string) "true-outer"
 #1   (string) "true-inner"
 #2   (string) "false-inner"
 #3   (string) "false-outer"
Bytecode
 0    TRUE
 1    OP_JUMP_IF_FALSE #15
 2    LOAD_CONSTANT #0
 3    PRINT
 4    TRUE
 5    OP_JUMP_IF_FALSE #10
 6    LOAD_CONSTANT #1
 7    PRINT
 8    OP_POPN 0
 9    OP_JUMP #13
 10   LOAD_CONSTANT #2
 11   PRINT
 12   OP_POPN 0
 13   OP_POPN 0
 14   OP_JUMP #18
 15   LOAD_CONSTANT #3
 16   PRINT
 17   OP_POPN 0

Failed: compiledCode.bytecodeArray.values[17].maybeOperand1 == 10
------------------------------

Assertions run: 490, failed: 2.
Tests run: 54, failed: 2. (0.00701s)
FAILED
make: *** [test] Error 1
```