### PR TITLE
Add block expressions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
     {
       "id": "testFile",
       "type": "promptString",
-      "description": "SolScript '.ss' file to debug.",
+      "description": "SolScript '.sol' file to debug.",
       "default": "./code.sol"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ print-statement:
 expression:
   struct-expression
   function-expression
-  block-expression
   logical-or-expression
 
 
@@ -222,6 +221,7 @@ postfix-expression:
 primary-expression:
   number-literal
   string-literal
+  block-expression
   identifier
   ( expression )
   "true"
@@ -333,16 +333,17 @@ The following features are necessary a proper v1.0 release, in rough order:
  - [X] Implement additive expression
  - [X] Implement all other "simple" expressions, i.e. excluding call-expressions
  - [X] Implement string literals
- - [X] Implement block statements and expressions
+ - [X] Implement block statements
  - [X] Add [_FAST](https://stackoverflow.com/questions/74998947/whats-pythons-load-fast-bytecode-instruction-fast-at) local variables
  - [X] Implement selection statement (`if`s)
- - [ ] Implement the rest of the parser for the whole syntax grammar
  - [X] Add conditional debugging/logging for tests that fail
+ - [X] Implement block expressions
  - [ ] Implement functions and returns
+ - [ ] Implement iteration statement (loops)
  - [ ] Implement assignment statements
+ - [ ] Implement the rest of the parser for the whole syntax grammar
  - [ ] Add CLI argument to enable or disable debugging logs in the REPL.
  - [ ] Improve error logs; print line and column
- - [ ] Implement iteration statement (loops)
  - [ ] Add Panic Mode error recovery; stop crashing the compiler on every error.
  - [ ] Implement objects / structs
  - [ ] Add garbage collector

--- a/src/bytecode.h
+++ b/src/bytecode.h
@@ -23,6 +23,7 @@ typedef enum {
     OP_POPN,                // pop N values from the stack
     OP_JUMP_IF_FALSE,       // pop the value on top of the stack, and jump it's falsy
     OP_JUMP,                // jump unconditionally
+    OP_SWAP,                // swap the value at the top of the stack with a value N positions below
 
     // Unary operations
     OP_UNARY_NEGATE,  // -stack[-1]

--- a/src/config.h
+++ b/src/config.h
@@ -5,8 +5,9 @@
 // capture standard output to confirm things are being printed correctly.
 #ifndef ENV_TEST
 
-#define DEBUG_COMPILER 0
-#define DEBUG_VM 0
+#define DEBUG_PARSER 1
+#define DEBUG_COMPILER 1
+#define DEBUG_VM 1
 
 #else
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -395,7 +395,7 @@ void printCompiledCode(CompiledCode compiledCode) {
 
 // Print VM stack. The top of the stack will be on the left.
 void printStack(const Value* topOfStack, const Value* bottomOfStack) {
-    printf(KGRY "[ " RESET);
+    printf(KGRY "t[ " RESET);
     while (topOfStack != bottomOfStack) {
         topOfStack--;
         Value val = *topOfStack;
@@ -414,5 +414,5 @@ void printStack(const Value* topOfStack, const Value* bottomOfStack) {
                 break;
         }
     }
-    printf(KGRY "]\n" RESET);
+    printf(KGRY "]b\n" RESET);
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -230,6 +230,14 @@ static void printExpression(const Expression* expression, int depth) {
             printBinaryExpression(expression->as.logicalOrExpression, LogicalOrExpression);
             break;
         }
+        case BLOCK_EXPRESSION:
+            printf("BlockExpression" KGRY "(numberOfStatements=%zu)\n" RESET, expression->as.blockExpression->statementArray.used);
+            BlockExpression* blockExpr = expression->as.blockExpression;
+            for (int i = 0; i < blockExpr->statementArray.used; i++) {
+                printStatement(blockExpr->statementArray.values[i], depth + 1);
+            }
+            printExpression(blockExpr->lastExpression, depth + 1);
+            break;
     }
 }
 
@@ -366,6 +374,9 @@ static void printBytecodeArray(BytecodeArray bytecodeArray) {
                 break;
             case OP_JUMP:
                 printf("OP_JUMP #%zu\n", bytecodeArray.values[i].maybeOperand1);
+                break;
+            case OP_SWAP:
+                printf("OP_SWAP #%zu\n", bytecodeArray.values[i].maybeOperand1);
                 break;
         }
     }

--- a/src/parser.c
+++ b/src/parser.c
@@ -447,7 +447,7 @@ static Expression* blockExpression(ASTParser* parser) {
     }
     consume(parser, TOKEN_RIGHT_CURLY, "Unclosed block expression. Expected '}'.");
 
-    // Block expressions must have at least one statement in them.
+    // Block expressions must have at one expression in them.
     if (!blockExpr->statementArray.used && !blockExpr->lastExpression) errorAtCurrent(parser, "Encountered an empty block-expression.");
 
     // Make the last ExpressionStatement the block's `lastExpression`

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -16,6 +16,7 @@ typedef struct EqualityExpression EqualityExpression;
 typedef struct ComparisonExpression ComparisonExpression;
 typedef struct AdditiveExpression AdditiveExpression;
 typedef struct MultiplicativeExpression MultiplicativeExpression;
+typedef struct BlockExpression BlockExpression;
 typedef struct UnaryExpression UnaryExpression;
 typedef struct PrimaryExpression PrimaryExpression;
 typedef struct BooleanLiteral BooleanLiteral;
@@ -40,6 +41,7 @@ typedef enum {
     COMPARISON_EXPRESSION,      // Stack effect: -1
     ADDITIVE_EXPRESSION,        // Stack effect: -1
     MULTIPLICATIVE_EXPRESSION,  // Stack effect: -1
+    BLOCK_EXPRESSION,           // Stack effect: 0
     UNARY_EXPRESSION,           // Stack effect: 0
     PRIMARY_EXPRESSION          // Stack effect: 0 per se
 } ExpressionType;
@@ -72,6 +74,7 @@ typedef struct {
         ComparisonExpression *comparisonExpression;
         AdditiveExpression *additiveExpression;
         MultiplicativeExpression *multiplicativeExpression;
+        BlockExpression *blockExpression;
         UnaryExpression *unaryExpression;
         PrimaryExpression *primaryExpression;
     } as;
@@ -149,6 +152,11 @@ struct MultiplicativeExpression {
     Expression *leftExpression;
     Expression *rightExpression;
     Token punctuator;
+};
+
+struct BlockExpression {
+    StatementArray statementArray;
+    Expression *lastExpression;
 };
 
 struct UnaryExpression {

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -41,7 +41,7 @@ typedef enum {
     COMPARISON_EXPRESSION,      // Stack effect: -1
     ADDITIVE_EXPRESSION,        // Stack effect: -1
     MULTIPLICATIVE_EXPRESSION,  // Stack effect: -1
-    BLOCK_EXPRESSION,           // Stack effect: 0
+    BLOCK_EXPRESSION,           // Stack effect: 0 per se
     UNARY_EXPRESSION,           // Stack effect: 0
     PRIMARY_EXPRESSION          // Stack effect: 0 per se
 } ExpressionType;

--- a/src/vm.c
+++ b/src/vm.c
@@ -273,6 +273,15 @@ void step(VM* vm) {
             vm->IP = &(vm->compiledCode.bytecodeArray.values[IPToJumpTo - 1]);
             break;
         }
+        case OP_SWAP: {
+            // Example: Swap(2) will swap [X X X A B C] -> [X X X C B A]
+            size_t targetPositionFromTopOfStack = (vm->SP - vm->stack - 1) - instruction->maybeOperand1;
+
+            Value tempValue = vm->stack[targetPositionFromTopOfStack];
+            vm->stack[targetPositionFromTopOfStack] = *(vm->SP - 1);
+            *(vm->SP - 1) = tempValue;
+            break;
+        }
         default:
             // Handle any unknown or unimplemented opcodes.
             fprintf(stderr, "Unimplemented opcode %d\n", instruction->type);

--- a/test/solscript/block_expressions/block_assignment.sol
+++ b/test/solscript/block_expressions/block_assignment.sol
@@ -1,0 +1,4 @@
+val a = { val b = 1; b + 2; }
+if (a == 3) {
+    print "Passed";
+}

--- a/test/solscript/block_expressions/block_in_if_condition.sol
+++ b/test/solscript/block_expressions/block_in_if_condition.sol
@@ -1,0 +1,3 @@
+if ({ val a = 1; a > 0; }) {
+    print "Passed";
+}

--- a/test/solscript/block_expressions/empty_block.sol
+++ b/test/solscript/block_expressions/empty_block.sol
@@ -1,0 +1,1 @@
+2 + {}; // Should throw error "Encountered an empty block-expression"

--- a/test/solscript/block_expressions/nested_blocks_trivial.sol
+++ b/test/solscript/block_expressions/nested_blocks_trivial.sol
@@ -1,0 +1,2 @@
+val a = {{{ "Correct!"; };}}
+print a;

--- a/test/solscript/block_expressions/no_final_expression.sol
+++ b/test/solscript/block_expressions/no_final_expression.sol
@@ -1,5 +1,3 @@
 val a = { 
     val b = 2; 
-    3;
-};
-print a;
+}; // should throw error

--- a/test/solscript/block_expressions/no_semi_colon_after_block.sol
+++ b/test/solscript/block_expressions/no_semi_colon_after_block.sol
@@ -1,0 +1,10 @@
+val a = { 
+    val b = 2; 
+    print "In block 1";
+    3;
+} // should NOT error
+
+2 + { 
+    print "In block 2"; 
+    4;    
+} // Expression statement; SHOULD error due to lack of semicolon after ExpressionStatement.

--- a/test/solscript/block_expressions/only_expression.sol
+++ b/test/solscript/block_expressions/only_expression.sol
@@ -1,0 +1,2 @@
+val a = { 3; };
+print a; // Should be 3

--- a/test/solscript/block_expressions/simple_example.sol
+++ b/test/solscript/block_expressions/simple_example.sol
@@ -2,4 +2,4 @@ val a = {
     val b = 2; 
     3;
 };
-print a;
+print a; // should be 3

--- a/test/solscript/errors/invalid_val_name.sol
+++ b/test/solscript/errors/invalid_val_name.sol
@@ -1,0 +1,2 @@
+val a'2 = 3;
+// Should throw "Error parsing val declaration. Unexpected character."

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -38,6 +38,10 @@ static void all_tests() {
     RUN_TEST(test_parser_block_statement);
     RUN_TEST(test_parser_if_statement_true_branch_only);
     RUN_TEST(test_parser_if_statement_with_else_branch);
+    RUN_TEST(test_parser_block_expression_simple);
+    RUN_TEST(test_parser_block_expression_nested);
+    RUN_TEST(test_parser_block_expression_with_statements);
+    RUN_TEST(test_parser_block_expression_as_if_condition);
 
     // Compiler tests
     RUN_TEST(test_compiler);
@@ -59,6 +63,9 @@ static void all_tests() {
     RUN_TEST(test_compiler_if_statement_no_else);
     RUN_TEST(test_compiler_if_statement_with_else);
     RUN_TEST(test_compiler_nested_if_statements);
+    RUN_TEST(test_compiler_block_expression_simple);
+    RUN_TEST(test_compiler_block_expression_nested);
+    RUN_TEST(test_compiler_block_expression_with_statements);
 
     // VM tests
     RUN_TEST(test_vm_addition);
@@ -74,6 +81,9 @@ static void all_tests() {
     RUN_TEST(test_vm_simple_block_statement_and_cleanup);
     RUN_TEST(test_vm_nested_blocks_with_global_and_local_vars);
     RUN_TEST(test_vm_nested_if_statements);
+    RUN_TEST(test_vm_simple_block_expression);
+    RUN_TEST(test_vm_block_expression_with_statements);
+    RUN_TEST(test_vm_block_expression_as_if_condition);
 }
 
 int main(int argc, char **argv) {

--- a/test/unit/src/vm_test.c
+++ b/test/unit/src/vm_test.c
@@ -572,3 +572,108 @@ int test_vm_nested_if_statements() {
 
     return SUCCESS_RETURN_CODE;  // Assuming SUCCESS_RETURN_CODE is defined as part of your testing framework
 }
+
+int test_vm_simple_block_expression() {
+    // val a = { 10; };
+    // print a;
+    CompiledCode code = (CompiledCode){
+        .constantPool = (ConstantPool){},
+        .bytecodeArray = (BytecodeArray){}};
+    INIT_ARRAY(code.bytecodeArray, Bytecode);
+    INIT_ARRAY(code.constantPool, Constant);
+
+    INSERT_ARRAY(code.constantPool, DOUBLE_CONST(10), Constant);   // Index 0
+    INSERT_ARRAY(code.constantPool, STRING_CONST("a"), Constant);  // Index 1
+
+    // Bytecode
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_SWAP, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_POPN, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_SET_GLOBAL_VAL, 1), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_GET_GLOBAL_VAL, 1), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_PRINT), Bytecode);
+
+    VM vm;
+    initVM(&vm, code);
+
+    CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "10.000000\n") == 0); });
+
+    FREE_ARRAY(code.bytecodeArray);
+    FREE_ARRAY(code.constantPool);
+
+    return SUCCESS_RETURN_CODE;
+}
+
+int test_vm_block_expression_with_statements() {
+    // val a = { val b = 5; b + 3; };
+    // print a;
+    CompiledCode code = (CompiledCode){
+        .constantPool = (ConstantPool){},
+        .bytecodeArray = (BytecodeArray){}};
+    INIT_ARRAY(code.bytecodeArray, Bytecode);
+    INIT_ARRAY(code.constantPool, Constant);
+
+    INSERT_ARRAY(code.constantPool, DOUBLE_CONST(5), Constant);    // Index 0
+    INSERT_ARRAY(code.constantPool, DOUBLE_CONST(3), Constant);    // Index 1
+    INSERT_ARRAY(code.constantPool, STRING_CONST("a"), Constant);  // Index 2
+
+    // Bytecode
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_SET_LOCAL_VAL_FAST), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_GET_LOCAL_VAL_FAST, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 1), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_BINARY_ADD), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_SWAP, 1), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_POPN, 1), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_SET_GLOBAL_VAL, 2), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_GET_GLOBAL_VAL, 2), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_PRINT), Bytecode);
+
+    VM vm;
+    initVM(&vm, code);
+
+    CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "8.000000\n") == 0); });
+
+    FREE_ARRAY(code.bytecodeArray);
+    FREE_ARRAY(code.constantPool);
+
+    return SUCCESS_RETURN_CODE;
+}
+
+int test_vm_block_expression_as_if_condition() {
+    // if ({ val a = 1; a > 0; }) { print "Passed"; }
+    CompiledCode code = (CompiledCode){
+        .constantPool = (ConstantPool){},
+        .bytecodeArray = (BytecodeArray){}};
+    INIT_ARRAY(code.bytecodeArray, Bytecode);
+    INIT_ARRAY(code.constantPool, Constant);
+
+    INSERT_ARRAY(code.constantPool, DOUBLE_CONST(1), Constant);         // Index 0
+    INSERT_ARRAY(code.constantPool, DOUBLE_CONST(0), Constant);         // Index 1
+    INSERT_ARRAY(code.constantPool, STRING_CONST("Passed"), Constant);  // Index 2
+
+    // Bytecode for the block expression
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_SET_LOCAL_VAL_FAST), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_GET_LOCAL_VAL_FAST, 0), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 1), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_BINARY_GT), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_SWAP, 1), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_POPN, 1), Bytecode);
+
+    // Bytecode for the if statement
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_JUMP_IF_FALSE, 11), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_LOAD_CONSTANT, 2), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE(OP_PRINT), Bytecode);
+    INSERT_ARRAY(code.bytecodeArray, BYTECODE_OPERAND_1(OP_POPN, 0), Bytecode);
+
+    VM vm;
+    initVM(&vm, code);
+
+    CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "Passed\n") == 0); });
+
+    FREE_ARRAY(code.bytecodeArray);
+    FREE_ARRAY(code.constantPool);
+
+    return SUCCESS_RETURN_CODE;
+}


### PR DESCRIPTION
### Summary

This PR adds block expressions. Block expressions are blocks with any number of statements followed by an expression at the end. They can be used wherever an expression is expected, for example:
```
val a = { val b = 1; b + 2; }    // This is a block expression.

if (a == 3) {
    print "Passed";
}
```

During code execution, the VM will (only) leave the `Value` produced by the final expression in the block on the stack. This is achieved by combining the `POPN` instruction with a new instruction, `SWAP(n)`. This instruciton swaps the topmost value of the stack with the n-th value in the stack. So for example, if a block expression produced 4 values, the VM will swap the 4th value with the 1st value, and pop the three values at the top. 

There's a slight modification to SolScript's grammar. `block-expression` is moved down to `primary-expression` alongisde parenthesis expressions (`( expression )`). This removes ambiguity and prevents infinite loops in the parser.

### Testing

Added `.sol` tests and manually verified the output.

Added unit tests for the parser, compiler, and VM.