### PR TITLE
Refactor `Compiler` -> `CompilerState` + `CompilerUnit`s

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,7 +69,8 @@
     "vm.h": "c",
     "typeinfo": "c",
     "limits.h": "c",
-    "stddef.h": "c"
+    "stddef.h": "c",
+    "utils.h": "c"
   },
   "C_Cpp.errorSquiggles": "enabled"
 }

--- a/src/bytecode.h
+++ b/src/bytecode.h
@@ -134,8 +134,7 @@ typedef struct {
 } CompiledCodeObject;
 
 /**
- * SolScript's compiled code consists of a constant pool and the bytecode.
- * This is all the information the VM needs to run.
+ * SolScript's compiled code consists of compiled code + metadata.
  */
 typedef struct {
     CompiledCodeObject topLevelCodeObject;

--- a/src/bytecode.h
+++ b/src/bytecode.h
@@ -129,8 +129,17 @@ typedef struct {
  * This is all the information the VM needs to run.
  */
 typedef struct {
-    ConstantPool constantPool;
+    ConstantPool constantPool;  // May contain nested CodeObjects (e.g. if a function is defined within another)
     BytecodeArray bytecodeArray;
+} CompiledCodeObject;
+
+/**
+ * SolScript's compiled code consists of a constant pool and the bytecode.
+ * This is all the information the VM needs to run.
+ */
+typedef struct {
+    CompiledCodeObject topLevelCodeObject;
+    // Other metadata can go in here
 } CompiledCode;
 
 #endif

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -15,55 +15,61 @@
 #include "vm.h"
 
 /**
- * Initialize PredictedStack with null values and stack height zero.
+ * Get new PredictedStack with null values and stack height zero.
  */
-static void initPredictedStack(PredictedStack* predictedStack) {
-    predictedStack->currentStackHeight = 0;
+static PredictedStack newPredictedStack() {
+    PredictedStack predictedStack;
+    predictedStack.currentStackHeight = 0;
 
     for (int i = 0; i < STACK_MAX; i++) {
-        predictedStack->tempStack[i].name = NULL;
+        predictedStack.tempStack[i].name = NULL;
     }
+    return predictedStack;
 }
 
-void initRootCompiler(Compiler* compiler, Source* ASTSource) {
+/**
+ * Initialize a CompilerUnit to compile a single unit of code, such as a function.
+ * Each compiler unit contains its own bytecode array and constant pool.
+ */
+CompilerUnit initCompilerUnit(CompilerUnit* maybeEnclosingCompilerUnit, HashTable* globals) {
+    CompilerUnit compilerUnit;
+
     BytecodeArray bytecodeArray;
     INIT_ARRAY(bytecodeArray, Bytecode);
     ConstantPool constantPool;
     INIT_ARRAY(constantPool, Constant);
-    compiler->compiledBytecode = bytecodeArray;
-    compiler->ASTSource = ASTSource;
-    compiler->constantPool = constantPool;
-    compiler->isInGlobalScope = true;
-    initHashTable(&compiler->tempGlobals);
 
-    PredictedStack* predictedStack = malloc(sizeof(PredictedStack));
-    compiler->predictedStack = predictedStack;
-    initPredictedStack(predictedStack);
+    compilerUnit.compiledCodeObject = (CompiledCodeObject){
+        .bytecodeArray = bytecodeArray,
+        .constantPool = constantPool};
+    compilerUnit.predictedStack = newPredictedStack();
+    compilerUnit.isInGlobalScope = maybeEnclosingCompilerUnit == NULL;  // Only the root compiler can be in global scope.
+    compilerUnit.globals = globals;
+    compilerUnit.enclosingCompilerUnit = maybeEnclosingCompilerUnit;
+
+    return compilerUnit;
 }
 
-Compiler* initFunctionCompiler(Compiler* enclosingCompiler) {
-    Compiler* compiler = malloc(sizeof(Compiler));
-
-    // Use same as parent:
-    compiler->compiledBytecode = enclosingCompiler->compiledBytecode;
-    compiler->ASTSource = enclosingCompiler->ASTSource;
-    compiler->constantPool = enclosingCompiler->constantPool;
-    compiler->isInGlobalScope = false;  // Only the root compiler can be in global scope.
-
-    // Use a separate stack for the function
-    PredictedStack* predictedStack = malloc(sizeof(PredictedStack));
-    compiler->predictedStack = predictedStack;
-    initPredictedStack(predictedStack);
+void initCompilerState(CompilerState* compilerState, Source* ASTSource) {
+    compilerState->ASTSource = ASTSource;
+    initHashTable(&compilerState->globals);
+    compilerState->currentCompilerUnit = initCompilerUnit(NULL, &compilerState->globals);
 }
 
-// TODO: add function to free compiler and use it in tests
-// void freeCompiler();
+void freeCompilerUnit(CompilerUnit compilerUnit) {
+    FREE_ARRAY(compilerUnit.compiledCodeObject.bytecodeArray);
+    FREE_ARRAY(compilerUnit.compiledCodeObject.constantPool);
+}
+
+void freeCompilerState(CompilerState* compilerState) {
+    freeCompilerUnit(compilerState->currentCompilerUnit);
+}
 
 /* FORWARD DECLARATIONS */
 
-static void visitStatement(Compiler* compiler, Statement* statement);
-static void visitExpression(Compiler* compiler, Expression* expression);
-static void visitLiteral(Compiler* compiler, Literal* literal);
+static void visitStatement(CompilerUnit* compiler, Statement* statement);
+static void visitExpression(CompilerUnit* compiler, Expression* expression);
+static void visitLiteral(CompilerUnit* compiler, Literal* literal);
 
 /* UTILITIES */
 
@@ -74,13 +80,11 @@ static void visitLiteral(Compiler* compiler, Literal* literal);
  * then after all statements have been compiled print all errors and exit the program.
  */
 #if DEBUG_COMPILER
-#define errorAndExit(...)                                \
-    {                                                    \
-        printCompiledCode((CompiledCode){                \
-            .bytecodeArray = compiler->compiledBytecode, \
-            .constantPool = compiler->constantPool});    \
-        fprintf(stderr, __VA_ARGS__);                    \
-        exit(EXIT_FAILURE);                              \
+#define errorAndExit(...)                                      \
+    {                                                          \
+        printCompiledCodeObject(compiler->compiledCodeObject); \
+        fprintf(stderr, __VA_ARGS__);                          \
+        exit(EXIT_FAILURE);                                    \
     }
 #else
 #define errorAndExit(...)             \
@@ -91,23 +95,23 @@ static void visitLiteral(Compiler* compiler, Literal* literal);
 #endif
 
 // Add bytecode to the compiled program.
-static void emitBytecode(Compiler* compiler, Bytecode bytecode) {
-    INSERT_ARRAY(compiler->compiledBytecode, bytecode, Bytecode);
+static void emitBytecode(CompilerUnit* compiler, Bytecode bytecode) {
+    INSERT_ARRAY(compiler->compiledCodeObject.bytecodeArray, bytecode, Bytecode);
 }
 
 /**
  * The compiler can know in advance how tall the VM stack will be at any point. This function helps keep track
  * of the height. For example, a local variable declaration increases the stack by 1 (locals live on the stack).
  */
-static void increaseStackHeight(Compiler* compiler) {
-    if (compiler->predictedStack->currentStackHeight == UCHAR_MAX) {
+static void increaseStackHeight(CompilerUnit* compiler) {
+    if (compiler->predictedStack.currentStackHeight == UCHAR_MAX) {
         errorAndExit(
             "StackOverflowError: The Compiler has predicted that this code will "
             "cause the VM stack to overflow.");  // This error often indicates that something is wrong
                                                  // with how the compiler tracks the predicted stack height
     }
 
-    compiler->predictedStack->currentStackHeight++;
+    compiler->predictedStack.currentStackHeight++;
 }
 
 /**
@@ -120,10 +124,10 @@ static void increaseStackHeight(Compiler* compiler) {
  *  decreaseStackHeight(1)
  *  Stack: [A B C(top) ? ? ?]
  */
-static void decreaseStackHeight(Compiler* compiler) {
-    if (compiler->predictedStack->currentStackHeight > 0) {
-        compiler->predictedStack->tempStack[compiler->predictedStack->currentStackHeight - 1].name = NULL;
-        compiler->predictedStack->currentStackHeight--;
+static void decreaseStackHeight(CompilerUnit* compiler) {
+    if (compiler->predictedStack.currentStackHeight > 0) {
+        compiler->predictedStack.tempStack[compiler->predictedStack.currentStackHeight - 1].name = NULL;
+        compiler->predictedStack.currentStackHeight--;
     } else
         errorAndExit("InvalidStateException: the Compiler attempted to decrease the predicted stack height below 0.")
 }
@@ -150,20 +154,20 @@ char* copyStringToHeap(const char* chars, int length) {
  * TODO: this method is terribly inefficient as it iterates through the entire table. We should keep a hash table
  * of (number -> index in table) on the side and discard it after compilation is done.
  */
-static size_t findConstantInPool(Compiler* compiler, Constant constant) {
-    for (size_t i = 0; i < compiler->constantPool.used; i++) {
+static size_t findConstantInPool(CompilerUnit* compiler, Constant constant) {
+    for (size_t i = 0; i < compiler->compiledCodeObject.constantPool.used; i++) {
         // Skip if its not the same type
-        if (constant.type != compiler->constantPool.values[i].type) continue;
+        if (constant.type != compiler->compiledCodeObject.constantPool.values[i].type) continue;
 
         // Check if value is the same
-        switch (compiler->constantPool.values[i].type) {
+        switch (compiler->compiledCodeObject.constantPool.values[i].type) {
             case CONST_TYPE_STRING:
             case CONST_TYPE_IDENTIFIER:
-                if (strcmp(constant.as.string, compiler->constantPool.values[i].as.string) == 0) return i;
+                if (strcmp(constant.as.string, compiler->compiledCodeObject.constantPool.values[i].as.string) == 0) return i;
                 break;
 
             case CONST_TYPE_DOUBLE:
-                if (constant.as.number == compiler->constantPool.values[i].as.number) return i;
+                if (constant.as.number == compiler->compiledCodeObject.constantPool.values[i].as.number) return i;
                 break;
         }
     }
@@ -175,28 +179,28 @@ static size_t findConstantInPool(Compiler* compiler, Constant constant) {
  * If the constant is already in the pool, the index of the existing one is returned.
  * (These constants go alongwise the bytecode in the compiled code.)
  * */
-static size_t addConstantToPool(Compiler* compiler, Constant constant) {
+static size_t addConstantToPool(CompilerUnit* compiler, Constant constant) {
     // Check if its already there
     size_t maybeIndexInPool = findConstantInPool(compiler, constant);
     if (maybeIndexInPool != -1) return maybeIndexInPool;
 
     // If not, insert and return index
-    INSERT_ARRAY(compiler->constantPool, constant, Constant);
-    return compiler->constantPool.used - 1;
+    INSERT_ARRAY(compiler->compiledCodeObject.constantPool, constant, Constant);
+    return compiler->compiledCodeObject.constantPool.used - 1;
 }
 
 /**
  * Add a global variable to the compiler's table of globals.
  */
-static void addGlobalToTable(Compiler* compiler, char* name, bool isConstant) {
-    hashTableInsert(&compiler->tempGlobals, name, (Value){.as.booleanVal = isConstant});
+static void addGlobalToTable(CompilerUnit* compiler, char* name, bool isConstant) {
+    hashTableInsert(compiler->globals, name, (Value){.as.booleanVal = isConstant});
 }
 /**
  * Check if a global variable in the compiler's table of globals is constant (i.e. `val`).
  * Throws an error if the global doesn't exist.
  */
-static bool isGlobalInTable(Compiler* compiler, char* name) {
-    HashTableEntry* entry = hashTableGet(&compiler->tempGlobals, name);
+static bool isGlobalInTable(CompilerUnit* compiler, char* name) {
+    HashTableEntry* entry = hashTableGet(compiler->globals, name);
     return entry->key != NULL;
 }
 
@@ -204,8 +208,8 @@ static bool isGlobalInTable(Compiler* compiler, char* name) {
  * Check if a global variable in the compiler's table of globals is constant (i.e. `val`).
  * Throws an error if the global doesn't exist.
  */
-static bool isGlobalConstant(Compiler* compiler, char* name) {
-    HashTableEntry* entry = hashTableGet(&compiler->tempGlobals, name);
+static bool isGlobalConstant(CompilerUnit* compiler, char* name) {
+    HashTableEntry* entry = hashTableGet(compiler->globals, name);
     if (entry) {
         return entry->value.as.booleanVal;
     } else {
@@ -221,14 +225,14 @@ static bool isGlobalConstant(Compiler* compiler, char* name) {
  *
  * Returns either the stack index if found, or -1 if not found.
  */
-static int findLocalByName(Compiler* compiler, char* name) {
-    for (int i = compiler->predictedStack->currentStackHeight; i >= 0; i--) {
+static int findLocalByName(CompilerUnit* compiler, char* name) {
+    for (int i = compiler->predictedStack.currentStackHeight; i >= 0; i--) {
         // Skip NULL entries. (These may exists because our temp stack only keeps track of locals.
         // Anything else that's on the stack is a NULL here)
-        if (compiler->predictedStack->tempStack[i].name == NULL) continue;
+        if (compiler->predictedStack.tempStack[i].name == NULL) continue;
 
         // See if name matches
-        if (strcmp(name, compiler->predictedStack->tempStack[i].name) == 0) return i;
+        if (strcmp(name, compiler->predictedStack.tempStack[i].name) == 0) return i;
     }
     return -1;  // Not declared
 }
@@ -237,51 +241,51 @@ static int findLocalByName(Compiler* compiler, char* name) {
  * Check if a local variable in the compiler's table of locals is constant (i.e. `val`).
  * Throws an error if the local doesn't exist.
  */
-static int isLocalConstant(Compiler* compiler, char* name) {
+static int isLocalConstant(CompilerUnit* compiler, char* name) {
     int index = findLocalByName(compiler, name);
     if (index == -1)
         errorAndExit(
             "InvalidStateException: Attempted to check if a local variable is constant, but the "
             "local doesn't exist.") else {
-            return compiler->predictedStack->tempStack[index].isConstant;
+            return compiler->predictedStack.tempStack[index].isConstant;
         }
 }
 /**
  * Check if a local variable in the compiler's table of locals is constant (i.e. `val`).
  * Throws an error if the local doesn't exist.
  */
-static int isLocalConstantByIndex(Compiler* compiler, int indexInTempStack) {
+static int isLocalConstantByIndex(CompilerUnit* compiler, int indexInTempStack) {
     if (indexInTempStack == -1)
         errorAndExit(
             "InvalidStateException: Attempted to check if a local variable is constant, but the "
             "local doesn't exist.") else {
-            return compiler->predictedStack->tempStack[indexInTempStack].isConstant;
+            return compiler->predictedStack.tempStack[indexInTempStack].isConstant;
         }
 }
 
 /**
  * Add a local variable to the Compiler's temporary stack..
  */
-static void addLocalToTempStack(Compiler* compiler, char* name, bool isConstant) {
+static void addLocalToTempStack(CompilerUnit* compiler, char* name, bool isConstant) {
     // The local will be right below the current stack height
-    compiler->predictedStack->tempStack[compiler->predictedStack->currentStackHeight - 1] = (Local){.name = name, .isConstant = isConstant};
+    compiler->predictedStack.tempStack[compiler->predictedStack.currentStackHeight - 1] = (Local){.name = name, .isConstant = isConstant};
 }
 
 /**
  * Remove N locals from the top of the Compiler's temporary stack.
  */
-static void removeLocalsFromTempStack(Compiler* compiler, int N) {
-    for (int i = compiler->predictedStack->currentStackHeight; i > compiler->predictedStack->currentStackHeight - N; i--) {
+static void removeLocalsFromTempStack(CompilerUnit* compiler, int N) {
+    for (int i = compiler->predictedStack.currentStackHeight; i > compiler->predictedStack.currentStackHeight - N; i--) {
         if (N < 0) {
             errorAndExit("Attempted to remove more local variables than exist in the stack. This should be impossible.");
         }
-        compiler->predictedStack->tempStack[i - 1].name = NULL;  // Setting the name to NULL frees up the spot
+        compiler->predictedStack.tempStack[i - 1].name = NULL;  // Setting the name to NULL frees up the spot
     }
 }
 
 /* VISITOR FUNCTIONS */
 
-static void visitAdditiveExpression(Compiler* compiler, AdditiveExpression* additiveExpression) {
+static void visitAdditiveExpression(CompilerUnit* compiler, AdditiveExpression* additiveExpression) {
     visitExpression(compiler, additiveExpression->leftExpression);
     visitExpression(compiler, additiveExpression->rightExpression);
 
@@ -298,7 +302,7 @@ static void visitAdditiveExpression(Compiler* compiler, AdditiveExpression* addi
     decreaseStackHeight(compiler);
 }
 
-static void visitMultiplicativeExpression(Compiler* compiler, MultiplicativeExpression* multiplicativeExpression) {
+static void visitMultiplicativeExpression(CompilerUnit* compiler, MultiplicativeExpression* multiplicativeExpression) {
     visitExpression(compiler, multiplicativeExpression->leftExpression);
     visitExpression(compiler, multiplicativeExpression->rightExpression);
 
@@ -315,7 +319,7 @@ static void visitMultiplicativeExpression(Compiler* compiler, MultiplicativeExpr
     decreaseStackHeight(compiler);
 }
 
-static void visitEqualityExpression(Compiler* compiler, EqualityExpression* equalityExpression) {
+static void visitEqualityExpression(CompilerUnit* compiler, EqualityExpression* equalityExpression) {
     visitExpression(compiler, equalityExpression->leftExpression);
     visitExpression(compiler, equalityExpression->rightExpression);
 
@@ -332,14 +336,14 @@ static void visitEqualityExpression(Compiler* compiler, EqualityExpression* equa
     decreaseStackHeight(compiler);
 }
 
-static void visitLogicalOrExpression(Compiler* compiler, LogicalOrExpression* logicalOrExpression) {
+static void visitLogicalOrExpression(CompilerUnit* compiler, LogicalOrExpression* logicalOrExpression) {
     visitExpression(compiler, logicalOrExpression->leftExpression);
     visitExpression(compiler, logicalOrExpression->rightExpression);
     emitBytecode(compiler, BYTECODE(OP_BINARY_LOGICAL_OR));
     decreaseStackHeight(compiler);
 }
 
-static void visitLogicalAndExpression(Compiler* compiler, LogicalAndExpression* logicalAndExpression) {
+static void visitLogicalAndExpression(CompilerUnit* compiler, LogicalAndExpression* logicalAndExpression) {
     visitExpression(compiler, logicalAndExpression->leftExpression);
     visitExpression(compiler, logicalAndExpression->rightExpression);
     emitBytecode(compiler, BYTECODE(OP_BINARY_LOGICAL_AND));
@@ -347,7 +351,7 @@ static void visitLogicalAndExpression(Compiler* compiler, LogicalAndExpression* 
 }
 
 // Visit the two expression on left and write, emit bytecode to add them
-static void visitComparisonExpression(Compiler* compiler, ComparisonExpression* comparisonExpression) {
+static void visitComparisonExpression(CompilerUnit* compiler, ComparisonExpression* comparisonExpression) {
     visitExpression(compiler, comparisonExpression->leftExpression);
     visitExpression(compiler, comparisonExpression->rightExpression);
 
@@ -370,7 +374,7 @@ static void visitComparisonExpression(Compiler* compiler, ComparisonExpression* 
     decreaseStackHeight(compiler);
 }
 
-static void visitUnaryExpression(Compiler* compiler, UnaryExpression* unaryExpression) {
+static void visitUnaryExpression(CompilerUnit* compiler, UnaryExpression* unaryExpression) {
     visitExpression(compiler, unaryExpression->rightExpression);
     if (unaryExpression->punctuator.type == TOKEN_MINUS) {
         emitBytecode(compiler, BYTECODE(OP_UNARY_NEGATE));
@@ -379,12 +383,12 @@ static void visitUnaryExpression(Compiler* compiler, UnaryExpression* unaryExpre
     }
 }
 
-static void visitPrimaryExpression(Compiler* compiler, PrimaryExpression* primaryExpression) {
+static void visitPrimaryExpression(CompilerUnit* compiler, PrimaryExpression* primaryExpression) {
     visitLiteral(compiler, primaryExpression->literal);
 }
 
 // Visit the expression. (Should be executed only for its side-effects)
-static void visitExpressionStatement(Compiler* compiler, ExpressionStatement* expressionStatement) {
+static void visitExpressionStatement(CompilerUnit* compiler, ExpressionStatement* expressionStatement) {
     visitExpression(compiler, expressionStatement->expression);
 
     // The expression will always add a Value to the stack, but by definition it's not used
@@ -393,7 +397,7 @@ static void visitExpressionStatement(Compiler* compiler, ExpressionStatement* ex
     decreaseStackHeight(compiler);
 }
 
-static void visitAssignmentStatement(Compiler* compiler, AssignmentStatement* assignmentStatement) {
+static void visitAssignmentStatement(CompilerUnit* compiler, AssignmentStatement* assignmentStatement) {
     // Compile the code to compute the new value
     visitExpression(compiler, assignmentStatement->value);
 
@@ -451,7 +455,7 @@ static void visitAssignmentStatement(Compiler* compiler, AssignmentStatement* as
  * Visit the expression after the val declaration, save the variable identifier to constant pool,
  * emit instruction to set identifier = val
  */
-static void visitValDeclarationStatement(Compiler* compiler, ValDeclarationStatement* valDeclarationStatement) {
+static void visitValDeclarationStatement(CompilerUnit* compiler, ValDeclarationStatement* valDeclarationStatement) {
     visitExpression(compiler, valDeclarationStatement->expression);
     // The expression will add 1 to the stack height. We leave the value on the stack - that's the variable.
 
@@ -477,7 +481,7 @@ static void visitValDeclarationStatement(Compiler* compiler, ValDeclarationState
     }
 }
 
-static void visitVarDeclarationStatement(Compiler* compiler, VarDeclarationStatement* varDeclarationStatement) {
+static void visitVarDeclarationStatement(CompilerUnit* compiler, VarDeclarationStatement* varDeclarationStatement) {
     bool isValueNull = varDeclarationStatement->maybeExpression == NULL;
     if (!isValueNull)
         visitExpression(compiler, varDeclarationStatement->maybeExpression);
@@ -511,18 +515,18 @@ static void visitVarDeclarationStatement(Compiler* compiler, VarDeclarationState
 }
 
 // Visit expression following print, then emit bytecode to print that expression
-static void visitPrintStatement(Compiler* compiler, PrintStatement* printStatement) {
+static void visitPrintStatement(CompilerUnit* compiler, PrintStatement* printStatement) {
     visitExpression(compiler, printStatement->expression);
     emitBytecode(compiler, BYTECODE(OP_PRINT));
     decreaseStackHeight(compiler);
 }
 
-static void visitBlockExpression(Compiler* compiler, BlockExpression* blockExpression) {
+static void visitBlockExpression(CompilerUnit* compiler, BlockExpression* blockExpression) {
     bool wasCompilerInGlobalScopeBeforeThisBlock = compiler->isInGlobalScope;
     compiler->isInGlobalScope = false;
 
     // Keep track of the stack height so we can later pop all the variables etc defined in it.
-    uint8_t stackHeightBeforeBlockStmt = compiler->predictedStack->currentStackHeight;
+    uint8_t stackHeightBeforeBlockStmt = compiler->predictedStack.currentStackHeight;
 
     for (size_t i = 0; i < blockExpression->statementArray.used; i++) {
         Statement* statement = blockExpression->statementArray.values[i];
@@ -537,7 +541,7 @@ static void visitBlockExpression(Compiler* compiler, BlockExpression* blockExpre
     }
 
     // Calculate the stack effect of this entire block so we can clean up at the end of the block.
-    uint8_t stackHeightAfterBlockStmt = compiler->predictedStack->currentStackHeight;
+    uint8_t stackHeightAfterBlockStmt = compiler->predictedStack.currentStackHeight;
     uint8_t blockStmtStackEffect = stackHeightAfterBlockStmt - stackHeightBeforeBlockStmt;
 
     // Swap the value at the top of the stack (the Value produced by the expression) with the first value
@@ -556,17 +560,17 @@ static void visitBlockExpression(Compiler* compiler, BlockExpression* blockExpre
     removeLocalsFromTempStack(compiler, blockStmtStackEffect - 1);
 
     // Undo stack height, except for final expression
-    compiler->predictedStack->currentStackHeight = stackHeightBeforeBlockStmt + 1;
+    compiler->predictedStack.currentStackHeight = stackHeightBeforeBlockStmt + 1;
 
     compiler->isInGlobalScope = wasCompilerInGlobalScopeBeforeThisBlock;
 }
 
-static void visitBlockStatement(Compiler* compiler, BlockStatement* blockStatement) {
+static void visitBlockStatement(CompilerUnit* compiler, BlockStatement* blockStatement) {
     bool wasCompilerInGlobalScopeBeforeThisBlock = compiler->isInGlobalScope;
     compiler->isInGlobalScope = false;
 
     // Keep track of the stack height so we can later pop all the variables etc defined in it.
-    uint8_t stackHeightBeforeBlockStmt = compiler->predictedStack->currentStackHeight;
+    uint8_t stackHeightBeforeBlockStmt = compiler->predictedStack.currentStackHeight;
 
     for (size_t i = 0; i < blockStatement->statementArray.used; i++) {
         Statement* statement = blockStatement->statementArray.values[i];
@@ -574,7 +578,7 @@ static void visitBlockStatement(Compiler* compiler, BlockStatement* blockStateme
     }
 
     // Calculate the stack effect of this entire block so we can clean up at the end of the block.
-    uint8_t stackHeightAfterBlockStmt = compiler->predictedStack->currentStackHeight;
+    uint8_t stackHeightAfterBlockStmt = compiler->predictedStack.currentStackHeight;
     uint8_t blockStmtStackEffect = stackHeightAfterBlockStmt - stackHeightBeforeBlockStmt;
 
     // Pop all the Values that were put in the VM stack in the block.
@@ -585,19 +589,19 @@ static void visitBlockStatement(Compiler* compiler, BlockStatement* blockStateme
     removeLocalsFromTempStack(compiler, blockStmtStackEffect);
 
     // Undo stack height
-    compiler->predictedStack->currentStackHeight = stackHeightBeforeBlockStmt;
+    compiler->predictedStack.currentStackHeight = stackHeightBeforeBlockStmt;
 
     compiler->isInGlobalScope = wasCompilerInGlobalScopeBeforeThisBlock;
 }
 
-static void visitSelectionStatement(Compiler* compiler, SelectionStatement* selectionStatement) {
+static void visitSelectionStatement(CompilerUnit* compiler, SelectionStatement* selectionStatement) {
     // Visit the condition
     visitExpression(compiler, selectionStatement->conditionExpression);
 
     // Emit bytecode for conditional jump, keep track of its index in jumpIfFalsePosition.
     // 999999 is a placeholder. We don't know how much bytecode is in the statement for the "then" branch so
     // we will have to come back and patch this placeholder.
-    size_t jumpIfFalsePosition = compiler->compiledBytecode.used;
+    size_t jumpIfFalsePosition = compiler->compiledCodeObject.bytecodeArray.used;
     emitBytecode(compiler, BYTECODE_OPERAND_1(OP_JUMP_IF_FALSE, 999999));
 
     // Visiting the expression grows the stack, but running OP_JUMP_IF_FALSE in the VM will
@@ -610,18 +614,18 @@ static void visitSelectionStatement(Compiler* compiler, SelectionStatement* sele
     // If there's an else branch, we need to jump over it once the true branch is executed
     size_t jumpToEndPosition = 0;
     if (selectionStatement->falseStatement != NULL) {
-        jumpToEndPosition = compiler->compiledBytecode.used;
+        jumpToEndPosition = compiler->compiledCodeObject.bytecodeArray.used;
         emitBytecode(compiler, BYTECODE_OPERAND_1(OP_JUMP, 999999));  // We'll have to patch this too
     }
 
     // Patch the jump-if-false position now that we know where to jump
-    compiler->compiledBytecode.values[jumpIfFalsePosition].maybeOperand1 = compiler->compiledBytecode.used;
+    compiler->compiledCodeObject.bytecodeArray.values[jumpIfFalsePosition].maybeOperand1 = compiler->compiledCodeObject.bytecodeArray.used;
 
     // Visit the false (a.k.a. "else") branch if it exists.
     if (selectionStatement->falseStatement != NULL) {
         visitStatement(compiler, selectionStatement->falseStatement);
         // Back-patch the jump-to-end position.
-        compiler->compiledBytecode.values[jumpToEndPosition].maybeOperand1 = compiler->compiledBytecode.used;
+        compiler->compiledCodeObject.bytecodeArray.values[jumpToEndPosition].maybeOperand1 = compiler->compiledCodeObject.bytecodeArray.used;
     }
 }
 
@@ -635,9 +639,9 @@ static void visitSelectionStatement(Compiler* compiler, SelectionStatement* sele
  *
  * TODO: benchmark having condition at the end of the loop and doing a jump-if-true to start
  */
-static void visitIterationStatement(Compiler* compiler, IterationStatement* iterationStatement) {
+static void visitIterationStatement(CompilerUnit* compiler, IterationStatement* iterationStatement) {
     // Keep a pointer to the condition expression so we can jump to it later
-    size_t expressionInstructionPosition = compiler->compiledBytecode.used;
+    size_t expressionInstructionPosition = compiler->compiledCodeObject.bytecodeArray.used;
 
     // Compile the actual expression
     visitExpression(compiler, iterationStatement->conditionExpression);
@@ -645,7 +649,7 @@ static void visitIterationStatement(Compiler* compiler, IterationStatement* iter
     // In the VM, if the expression is falsey, we need to jump past the body of the loop.
     // '999999' is a placeholder; at this point we don't know how much bytecode the body will
     // emit, so we need to use placeholder and patch it later.
-    size_t jumpIfFalsePosition = compiler->compiledBytecode.used;
+    size_t jumpIfFalsePosition = compiler->compiledCodeObject.bytecodeArray.used;
     emitBytecode(compiler, BYTECODE_OPERAND_1(OP_JUMP_IF_FALSE, 999999));
 
     // Visiting the expression grows the stack, but running OP_JUMP_IF_FALSE in the VM will
@@ -659,11 +663,11 @@ static void visitIterationStatement(Compiler* compiler, IterationStatement* iter
     emitBytecode(compiler, BYTECODE_OPERAND_1(OP_JUMP, expressionInstructionPosition));
 
     // Now that we've compiled the body, we can patch the jump-if-false instruction
-    compiler->compiledBytecode.values[jumpIfFalsePosition].maybeOperand1 = compiler->compiledBytecode.used;
+    compiler->compiledCodeObject.bytecodeArray.values[jumpIfFalsePosition].maybeOperand1 = compiler->compiledCodeObject.bytecodeArray.used;
 }
 
 // Add number to constant pool and emit bytecode to load it onto the stack
-static void visitNumberLiteral(Compiler* compiler, NumberLiteral* numberLiteral) {
+static void visitNumberLiteral(CompilerUnit* compiler, NumberLiteral* numberLiteral) {
     double number = tokenTodouble(numberLiteral->token);
     Constant constant = DOUBLE_CONST(number);
     size_t constantIndex = addConstantToPool(compiler, constant);
@@ -674,7 +678,7 @@ static void visitNumberLiteral(Compiler* compiler, NumberLiteral* numberLiteral)
     increaseStackHeight(compiler);
 }
 
-static void visitBooleanLiteral(Compiler* compiler, BooleanLiteral* booleanLiteral) {
+static void visitBooleanLiteral(CompilerUnit* compiler, BooleanLiteral* booleanLiteral) {
     switch (booleanLiteral->token.type) {
         case TOKEN_FALSE:
             emitBytecode(compiler, BYTECODE(OP_FALSE));
@@ -689,7 +693,7 @@ static void visitBooleanLiteral(Compiler* compiler, BooleanLiteral* booleanLiter
     increaseStackHeight(compiler);
 }
 
-static void visitIdentifierLiteral(Compiler* compiler, IdentifierLiteral* identifierLiteral) {
+static void visitIdentifierLiteral(CompilerUnit* compiler, IdentifierLiteral* identifierLiteral) {
     char* identifierNameNullTerminated = strndup(identifierLiteral->token.start, identifierLiteral->token.length);
 
     // Check if the identifier is a local variable
@@ -717,7 +721,7 @@ static void visitIdentifierLiteral(Compiler* compiler, IdentifierLiteral* identi
     increaseStackHeight(compiler);
 }
 
-static void visitStringLiteral(Compiler* compiler, StringLiteral* stringLiteral) {
+static void visitStringLiteral(CompilerUnit* compiler, StringLiteral* stringLiteral) {
     // Remove "'s from left and right of the string
     char* stringTrimmedAndNullTerminated = strndup(stringLiteral->token.start + 1, stringLiteral->token.length - 2);
     Constant constant = (Constant){
@@ -731,7 +735,7 @@ static void visitStringLiteral(Compiler* compiler, StringLiteral* stringLiteral)
     increaseStackHeight(compiler);
 }
 
-static void visitLiteral(Compiler* compiler, Literal* literal) {
+static void visitLiteral(CompilerUnit* compiler, Literal* literal) {
     switch (literal->type) {
         case NUMBER_LITERAL:
             visitNumberLiteral(compiler, literal->as.numberLiteral);
@@ -752,7 +756,7 @@ static void visitLiteral(Compiler* compiler, Literal* literal) {
     }
 }
 
-static void visitExpression(Compiler* compiler, Expression* expression) {
+static void visitExpression(CompilerUnit* compiler, Expression* expression) {
     switch (expression->type) {
         case ADDITIVE_EXPRESSION:
             visitAdditiveExpression(compiler, expression->as.additiveExpression);
@@ -788,7 +792,7 @@ static void visitExpression(Compiler* compiler, Expression* expression) {
     }
 }
 
-static void visitStatement(Compiler* compiler, Statement* statement) {
+static void visitStatement(CompilerUnit* compiler, Statement* statement) {
     switch (statement->type) {
         case EXPRESSION_STATEMENT:
             visitExpressionStatement(compiler, statement->as.expressionStatement);
@@ -821,15 +825,15 @@ static void visitStatement(Compiler* compiler, Statement* statement) {
     }
 }
 
-CompiledCode compile(Compiler* rootCompiler) {
+CompiledCode compile(CompilerState* initializedRootCompilerState) {
 #if DEBUG_COMPILER
     clock_t startTime = clock();
     printf("Started compiling.\n");
 #endif
 
-    for (int i = 0; i < rootCompiler->ASTSource->numberOfStatements; i++) {
-        Statement* statement = rootCompiler->ASTSource->rootStatements[i];
-        visitStatement(rootCompiler, statement);
+    for (int i = 0; i < initializedRootCompilerState->ASTSource->numberOfStatements; i++) {
+        Statement* statement = initializedRootCompilerState->ASTSource->rootStatements[i];
+        visitStatement(&initializedRootCompilerState->currentCompilerUnit, statement);
     }
 
 #if DEBUG_COMPILER
@@ -839,8 +843,7 @@ CompiledCode compile(Compiler* rootCompiler) {
 #endif
 
     CompiledCode code = (CompiledCode){
-        .bytecodeArray = rootCompiler->compiledBytecode,
-        .constantPool = rootCompiler->constantPool};
+        .topLevelCodeObject = initializedRootCompilerState->currentCompilerUnit.compiledCodeObject};
 
     return code;
 }

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -44,30 +44,40 @@ typedef struct {
     Local tempStack[STACK_MAX];
 } PredictedStack;
 
+typedef struct CompilerUnit CompilerUnit;
 /**
- * Compiler struct to facilitate compiling an AST into bytecode.
+ * Compiler struct for an individual compilation task, such as a function compilation.
+ */
+struct CompilerUnit {
+    CompiledCodeObject compiledCodeObject;  // The code object being compiled
+    PredictedStack predictedStack;          // A predictive copy of the VM's stack so we can know at compile time what position
+                                            // local variables will be in. Holds only strings for variable names.
+    bool isInGlobalScope;                   // Track whether the compiler is currently in the global scope instead of in a block.
+                                            // This is used to distinguish between local variables and global variables.
+    HashTable* globals;                     // Reference to the hash table that keep track of globals to prevent redefinition and enforce constant `val`s.
+    CompilerUnit* enclosingCompilerUnit;    // Once this compiler unit is done compiling, return to the enclosing one
+};
+
+/**
+ * Singleton compiler struct to facilitate compiling an AST into bytecode.
  */
 typedef struct {
-    BytecodeArray compiledBytecode;
-    ConstantPool constantPool;
-    Source* ASTSource;  // Root of the AST
-
-    bool isInGlobalScope;  // Track whether the compiler is currently in the global scope instead of in a block.
-                           // This is used to distinguish between local variables and global variables.
-
-    PredictedStack* predictedStack;  // A predictive copy of the VM's stack so we can know at compile time what position
-                                     // local variables will be in. Holds only strings for variable names.
-    HashTable tempGlobals;           // A hash table to keep track of globals to prevent redefinition and enforce constant `val`s.
-} Compiler;
+    Source* ASTSource;                 // Root of the AST
+    HashTable globals;                 // A hash table to keep track of globals to prevent redefinition and enforce constant `val`s.
+    CompilerUnit currentCompilerUnit;  // The current compiler unit being executed.
+} CompilerState;
 
 /* Initialize a Compiler with an AST to be parsed */
-void initRootCompiler(Compiler* compiler, Source* ASTSource);
+void initCompilerState(CompilerState* compilerState, Source* ASTSource);
+
+/* Free a Compiler state and all of its fields, including the ASTSource*/
+void freeCompilerState(CompilerState* compilerState);
 
 /**
  * Compile an AST into bytecode.
  *
- * @param compiler an initialized Compiler to use for compiling.
+ * @param initializedRootCompilerState an initialized Compiler to use for compiling.
  */
-CompiledCode compile(Compiler* compiler);
+CompiledCode compile(CompilerState* initializedRootCompilerState);
 
 #endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -465,8 +465,14 @@ static void printBytecodeArray(BytecodeArray bytecodeArray) {
 
 void printCompiledCode(CompiledCode compiledCode) {
     printf("Compiled code:\n");
-    printConstantPool(compiledCode.constantPool);
-    printBytecodeArray(compiledCode.bytecodeArray);
+    printCompiledCodeObject(compiledCode.topLevelCodeObject);
+    printf("\n");
+}
+
+void printCompiledCodeObject(CompiledCodeObject compiledCodeObject) {
+    printf("Compiled code object:\n");
+    printConstantPool(compiledCodeObject.constantPool);
+    printBytecodeArray(compiledCodeObject.bytecodeArray);
     printf("\n");
 }
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -13,6 +13,7 @@ char const* tokenTypeToString(TokenType tokenType);
 void printAST(const Source* source);
 
 void printCompiledCode(CompiledCode compiledCode);
+void printCompiledCodeObject(CompiledCodeObject compiledCodeObject);
 
 void printStack(const Value* topOfStack, const Value* bottomOfStack);
 

--- a/src/main.c
+++ b/src/main.c
@@ -13,16 +13,15 @@
 
 static void repl() {
     // Use the same Compiler throughout the REPL session so we can add to the same constant pool
-    Compiler compiler;
-    initRootCompiler(&compiler, NULL);
+    CompilerState compiler;
+    initCompilerState(&compiler, NULL);
 
     // Use the same VM throughout the REPL session so we can maintain runtime values
     VM vm;
     BytecodeArray bytecodeArray;
     INIT_ARRAY(bytecodeArray, Bytecode);
     CompiledCode compiledCode = (CompiledCode){
-        .bytecodeArray = bytecodeArray,
-        .constantPool = compiler.constantPool};
+        .topLevelCodeObject = compiler.currentCompilerUnit.compiledCodeObject};
 
     initVM(&vm, compiledCode);
 
@@ -44,14 +43,14 @@ static void repl() {
         printAST(source);
 
         // Reset compiled bytecode and feed new AST, but maintain same constant pool
-        INIT_ARRAY(compiler.compiledBytecode, Bytecode);
+        INIT_ARRAY(compiler.currentCompilerUnit.compiledCodeObject.bytecodeArray, Bytecode);
         compiler.ASTSource = source;
         CompiledCode newCode = compile(&compiler);
         printCompiledCode(newCode);
 
         // Add new bytecode to VM
-        for (int i = 0; i < newCode.bytecodeArray.used; i++) {
-            vm.compiledCode.bytecodeArray.values[vm.compiledCode.bytecodeArray.used] = newCode.bytecodeArray.values[i];
+        for (int i = 0; i < newCode.topLevelCodeObject.bytecodeArray.used; i++) {
+            vm.compiledCode.bytecodeArray.values[vm.compiledCode.bytecodeArray.used] = newCode.topLevelCodeObject.bytecodeArray.values[i];
             vm.compiledCode.bytecodeArray.used++;
         }
         run(&vm);
@@ -79,8 +78,8 @@ static void executeFile(const char* path) {
     printAST(source);
 
     // Then, compile the AST into bytecode.
-    Compiler compiler;
-    initRootCompiler(&compiler, source);
+    CompilerState compiler;
+    initCompilerState(&compiler, source);
     CompiledCode compiledCode = compile(&compiler);
     printCompiledCode(compiledCode);
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -15,7 +15,7 @@
  * Initialize VM with some source code.
  */
 void initVM(VM* vm, CompiledCode compiledCode) {
-    vm->compiledCode = compiledCode;
+    vm->compiledCode = compiledCode.topLevelCodeObject;
     vm->IP = vm->compiledCode.bytecodeArray.values;  // Set instruction pointer to the beginning of bytecode
     vm->SP = vm->stack;                              // Set stack pointer to the top of the stack
     initHashTable(&vm->globals);

--- a/src/vm.h
+++ b/src/vm.h
@@ -19,7 +19,7 @@
  * @param SP the stack pointer (we use an actual pointer instead of an int index for faster dereferencing)
  * */
 typedef struct {
-    CompiledCode compiledCode;
+    CompiledCodeObject compiledCode;
     Bytecode* IP;
     Value stack[STACK_MAX];
     HashTable globals;


### PR DESCRIPTION
### Summary

This PR refactors the `Compiler` into `CompilerState` + `CompilerUnit`.
- `CompilerState` is a singleton that contains overall context of the compilation process.
- `CompilerUnit`s represent individual compilation tasks (e.g., for a single function) and produce a `CompiledCodeObject`.
- `CompiledCodeObject` contains the code and constants for a code unit (e.g. a function).
- **Motivation:** To facilitate function compilation, we will need "subcompilers" -- `CompilerUnit`s -- that compile code only within the context of that function execution.
  - In a later PR, a `CompilerUnit` will be able to have nested `CompilerUnits` via `Constants`. This will be useful for nested function executions
 - Overall, this approach to compilation is very similar and inspired by CPython's.

### Testing

All unit tests pass.

Manually tested the REPL and confirmed state is maintained across different statements;

Manually ran the following scenarios and confirmed correct output:
```
test/solscript/iteration_statements/while_loop_with_logical_operators.sol
test/solscript/if_statements/complex_nested_ifs_expressions.sol
test/solscript/general/globals_locals_ifs_expressions.sol
test/solscript/errors/local_use_before_declaration.sol
test/solscript/errors/global_use_before_declaration.sol
test/solscript/block_expressions/nested_blocks_trivial.sol
test/solscript/assignment/val_reassignment_global.sol
test/solscript/scope/nested_blocks.sol
```

### CPython Comparison
Take this code block
```
def outer():
    x = 10
    def inner():
        return x + 5
    return inner()
```
Here, `outer` would compile to:
```
1           0 LOAD_CONST               1 (10)
            2 STORE_FAST               0 (x)

2           4 LOAD_CLOSURE             0 (x)
            6 BUILD_TUPLE              1
            8 LOAD_CONST               2 (<code object inner at 0x...>)
           10 LOAD_CONST               3 ('outer.<locals>.inner')
           12 MAKE_FUNCTION            8 (closure)
           14 STORE_FAST               1 (inner)

4          16 LOAD_FAST                1 (inner)
           18 CALL_FUNCTION            0
           20 RETURN_VALUE
```
And `inner to
```
3           0 LOAD_DEREF               0 (x)
            2 LOAD_CONST               1 (5)
            4 BINARY_ADD
            6 RETURN_VALUE
```

In `outer`, we see a reference to inner's code object `(<code object inner at 0x...>)`. In SolScript, that will be a reference to inner's `CompiledCodeObject`.
