### PR TITLE
Add panic mode error recovery to Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,11 +351,11 @@ The following features are necessary a proper v1.0 release, in rough order:
  - [X] Implement functions and returns
  - [X] Add end-to-end tests
  - [x] Make debug logs optional for REPL or program execution
- - [ ] Improve error logs; print line and column
  - [ ] Add Panic Mode error recovery; stop crashing the compiler on every error.
+ - [ ] Improve error logs; print line and column
  - [ ] Implement objects / structs
- - [ ] Add garbage collector
  - [ ] Implement closures
+ - [ ] Add garbage collector
 
 ## v1.1 Tasks
  - [ ] Add native functions

--- a/code.sol
+++ b/code.sol
@@ -3,6 +3,8 @@ val f = lambda(b){ b+2; };
 print f(7);
 print f(8);
 
+das ds ads;
+
 print "";
 print "Expecting 5 and 25 to be printed:";
 val a = lambda(b, c){ print b+c; };

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -67,6 +67,7 @@ typedef struct {
     HashTable globals;                 // A hash table to keep track of globals to prevent redefinition and enforce constant `val`s.
     CompilerUnit currentCompilerUnit;  // The current compiler unit being executed.
     ErrorArray errors;
+    bool panicMode;  // This field is set while the compiler is recovering from an error
 } CompilerState;
 
 /* Initialize a Compiler with an AST to be parsed */

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 
 #include "bytecode.h"
+#include "error.h"
 #include "syntax.h"
 #include "token.h"
 #include "util/hash_table.h"
@@ -65,6 +66,7 @@ typedef struct {
     Source* ASTSource;                 // Root of the AST
     HashTable globals;                 // A hash table to keep track of globals to prevent redefinition and enforce constant `val`s.
     CompilerUnit currentCompilerUnit;  // The current compiler unit being executed.
+    ErrorArray errors;
 } CompilerState;
 
 /* Initialize a Compiler with an AST to be parsed */

--- a/src/error.c
+++ b/src/error.c
@@ -1,0 +1,30 @@
+#include "error.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "util/array.h"
+#include "util/colors.h"
+
+void initErrorArray(ErrorArray* errorArray) {
+    INIT_ARRAY((*errorArray), Error);
+}
+
+void addError(ErrorArray* errorArray, const char* message, Token token) {
+    Error error = {
+        .message = message,
+        .token = token};
+    INSERT_ARRAY((*errorArray), error, Error);
+}
+
+void printErrors(ErrorArray* errorArray) {
+    for (size_t i = 0; i < errorArray->used; i++) {
+        Error* error = &errorArray->values[i];
+        fprintf(stderr, KRED "Error" RESET " [line %d, column %d]: %s\n",
+                error->token.lineNo, error->token.colNo, error->message);
+    }
+}
+
+bool hadError(ErrorArray* errorArray) {
+    return errorArray->used > 0;
+}

--- a/src/error.c
+++ b/src/error.c
@@ -3,25 +3,81 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "util/array.h"
 #include "util/colors.h"
 
 void initErrorArray(ErrorArray* errorArray) {
     INIT_ARRAY((*errorArray), Error);
 }
 
-void addError(ErrorArray* errorArray, const char* message, Token token) {
+void addError(ErrorArray* errorArray, const char* message, Token token, ErrorType type) {
     Error error = {
         .message = message,
-        .token = token};
+        .token = token,
+        .type = type};
     INSERT_ARRAY((*errorArray), error, Error);
+}
+
+static char const* tokenTypeStrings[] = {
+    [SCANNER_ERROR] = "ScannerError",
+    [PARSER_ERROR] = "ParserError",
+    [COMPILER_ERROR] = "CompilerError",
+};
+
+void printErrorMessage(Error* error) {
+    const char* errorType = tokenTypeStrings[error->type];
+
+    fprintf(stderr, KRED "%s" RESET KGRY "[%d:%d]" RESET, errorType, error->token.lineNo, error->token.colNo);
+
+    if (error->token.type == TOKEN_EOF) {
+        fprintf(stderr, " at end");
+    } else if (error->token.type != TOKEN_ERROR) {
+        fprintf(stderr, " at '%.*s'", error->token.length, error->token.start);
+    }
+
+    fprintf(stderr, ": %s\n", error->message);
+}
+
+/**
+ * Using the Token in the Error, print the line of source code where the error
+ * occurred, plus a carat indicating the location of the error.
+ *
+ * This function is rudimentary and not super efficient, but that's ok because
+ * errors are not abundant and fast compilation speed is not one of SolScript's goals.
+ */
+static void printSourceLine(Error* error) {
+    // Find the beginning of the line
+    const char* lineStart = error->token.start;
+    while (lineStart > (error->token.start - error->token.colNo + error->token.length + 1) && lineStart[-1] != '\n') {
+        lineStart--;
+    }
+
+    // Find the end of the line
+    const char* lineEnd = error->token.start;
+    while (*lineEnd != '\0' && *lineEnd != '\n' && *lineEnd != EOF) {
+        lineEnd++;
+    }
+
+    // Print the line
+    int lineLength = lineEnd - lineStart;
+    if (lineLength > 0) {
+        fprintf(stderr, "    %.*s\n", lineLength, lineStart);
+    } else {
+        fprintf(stderr, "    <empty line>\n");
+    }
+
+    // Print the caret
+    for (int i = 0; i < (error->token.start - lineStart) + 4; i++) {
+        fprintf(stderr, " ");
+    }
+    fprintf(stderr, "^\n");
 }
 
 void printErrors(ErrorArray* errorArray) {
     for (size_t i = 0; i < errorArray->used; i++) {
         Error* error = &errorArray->values[i];
-        fprintf(stderr, KRED "Error" RESET " [line %d, column %d]: %s\n",
-                error->token.lineNo, error->token.colNo, error->message);
+        printErrorMessage(error);
+        printSourceLine(error);
+        fprintf(stderr, "\n");
     }
 }
 

--- a/src/error.c
+++ b/src/error.c
@@ -17,6 +17,14 @@ void addError(ErrorArray* errorArray, const char* message, Token token, ErrorTyp
     INSERT_ARRAY((*errorArray), error, Error);
 }
 
+void addErrorWithoutToken(ErrorArray* errorArray, const char* message, ErrorType type) {
+    Error error = {
+        .message = message,
+        .type = type,
+        .hasToken = false};
+    INSERT_ARRAY((*errorArray), error, Error);
+}
+
 static char const* tokenTypeStrings[] = {
     [SCANNER_ERROR] = "ScannerError",
     [PARSER_ERROR] = "ParserError",
@@ -76,7 +84,9 @@ void printErrors(ErrorArray* errorArray) {
     for (size_t i = 0; i < errorArray->used; i++) {
         Error* error = &errorArray->values[i];
         printErrorMessage(error);
-        printSourceLine(error);
+        if (error->hasToken) {
+            printSourceLine(error);
+        }
         fprintf(stderr, "\n");
     }
 }

--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,37 @@
+#ifndef sol_script_error_h
+#define sol_script_error_h
+
+#include <stdbool.h>
+
+#include "token.h"
+#include "util/array.h"
+
+/**
+ * Struct to represent a compile-time error, which could come from the
+ * scanner, parser, or compiler.
+ *
+ * The Token contains the location (line, column) of the error.
+ */
+typedef struct {
+    const char* message;
+    Token token;
+} Error;
+
+/**
+ * An array of compile-time errors. This struct can be used by the
+ * scanner, parser, or compiler, but it shouldn't be shared across them.
+ *
+ * The Token contains the location (line, column) of the error.
+ */
+typedef struct {
+    Error* values;
+    size_t used;
+    size_t size;
+} ErrorArray;
+
+void initErrorArray(ErrorArray* errorArray);
+void addError(ErrorArray* errorArray, const char* message, Token token);
+void printErrors(ErrorArray* errorArray);
+void freeErrorArray(ErrorArray* errorArray);
+
+#endif

--- a/src/error.h
+++ b/src/error.h
@@ -17,11 +17,15 @@ typedef enum {
  * scanner, parser, or compiler.
  *
  * The Token contains the location (line, column) of the error.
+ *
+ * For now, `hasToken` is necessary because the Compiler & VM don't have access
+ * to tokens. So we allow errors to not have tokens associated with them.
  */
 typedef struct {
     const char* message;
     Token token;
     ErrorType type;
+    bool hasToken;
 } Error;
 
 /**
@@ -39,6 +43,7 @@ typedef struct {
 
 void initErrorArray(ErrorArray* errorArray);
 void addError(ErrorArray* errorArray, const char* message, Token token, ErrorType type);
+void addErrorWithoutToken(ErrorArray* errorArray, const char* message, ErrorType type);
 void printErrors(ErrorArray* errorArray);
 void freeErrorArray(ErrorArray* errorArray);
 bool hadError(ErrorArray* errorArray);

--- a/src/error.h
+++ b/src/error.h
@@ -6,6 +6,12 @@
 #include "token.h"
 #include "util/array.h"
 
+typedef enum {
+    SCANNER_ERROR,
+    PARSER_ERROR,
+    COMPILER_ERROR,
+} ErrorType;
+
 /**
  * Struct to represent a compile-time error, which could come from the
  * scanner, parser, or compiler.
@@ -15,13 +21,15 @@
 typedef struct {
     const char* message;
     Token token;
+    ErrorType type;
 } Error;
 
 /**
  * An array of compile-time errors. This struct can be used by the
  * scanner, parser, or compiler, but it shouldn't be shared across them.
  *
- * The Token contains the location (line, column) of the error.
+ * A pointer to the source code is required so the line where the error
+ * occurred can be printed.
  */
 typedef struct {
     Error* values;
@@ -30,8 +38,9 @@ typedef struct {
 } ErrorArray;
 
 void initErrorArray(ErrorArray* errorArray);
-void addError(ErrorArray* errorArray, const char* message, Token token);
+void addError(ErrorArray* errorArray, const char* message, Token token, ErrorType type);
 void printErrors(ErrorArray* errorArray);
 void freeErrorArray(ErrorArray* errorArray);
+bool hadError(ErrorArray* errorArray);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -39,16 +39,13 @@ static void repl() {
         ASTParser treeParser;
 
         TokenArray tokens = scanTokensFromString(&scanner, input);
-        printTokenList(tokens);
 
         Source* source = parseASTFromTokens(&treeParser, &tokens);
-        printAST(source);
 
         // Reset compiled bytecode and feed new AST, but maintain same constant pool
         INIT_ARRAY(compiler.currentCompilerUnit.compiledCodeObject.bytecodeArray, Bytecode);
         compiler.ASTSource = source;
         CompiledCode newCode = compile(&compiler);
-        printCompiledCode(newCode);
 
         // Add new bytecode to VM
         for (int i = 0; i < newCode.topLevelCodeObject.bytecodeArray.used; i++) {

--- a/src/parser.h
+++ b/src/parser.h
@@ -2,6 +2,7 @@
 #define sol_script_tree_parser_h
 
 #include "array.h"
+#include "error.h"
 #include "token.h"
 
 // These are the types of syntax nodes SolScript has. We use it
@@ -16,14 +17,16 @@ typedef enum {
  *
  * @param tokenArray Array of tokens generated from the scanner.
  * @param current Current token. 0-indexed.
+ * @param previous The token just consumed.
  * @param source Root of the AST.
+ * @param errors Errors that occurred during parsing.
  * */
 typedef struct {
-    // Inputs from scanner
     TokenArray tokenArray;
-    Token* current;   // the token to be consumed next
-    Token* previous;  // the token just consumed
-    Source* source;   // Root of the AST
+    Token* current;
+    Token* previous;
+    Source* source;
+    ErrorArray errors;
 } ASTParser;
 
 /**

--- a/src/parser.h
+++ b/src/parser.h
@@ -51,10 +51,14 @@ Source* parseASTFromTokens(ASTParser* treeParser, TokenArray* tokenArray);
 
 /**
  * Free memory allocated for the Source of an AST.
- *
- * @param source the Source to free.
  */
 void freeSource(Source* source);
+
+/**
+ * Free memory allocated to the AST parser, but NOT its compiled AST.
+ * Use freeSource to free the AST.
+ */
+void freeParser(ASTParser* parser);
 
 /**
  *  Initialize treeParser at the beginning of the given token array to be parsed.


### PR DESCRIPTION
### Summary
Add panic mode error recovery to Parser.

This means that the parser will no longer exit on errors. Instead, it will move to the statement and continue. Errors will be reported in batch after the whole code is parsed.

### Testing
Added a `.sol` test and manually confirmed it works:

Code:
```
// Errors (on purpose);
val a = 2;
va b = 3;

prin 2;
print a;
```

Execution:
```
% make clean && make && ./sol test/manual/errors/parser_panic_mode_recovery.sol      
...
ParserError[3:6] at 'b': Expected ';' after expression-statement.
    va b = 3;
       ^

ParserError[5:8] at '2': Expected ';' after expression-statement.
    prin 2;
         ^

CompilerError. Identifier 'va' referenced before declaration.
```