### PR TITLE
Improve error recovery in the Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,11 +351,11 @@ The following features are necessary a proper v1.0 release, in rough order:
  - [X] Implement functions and returns
  - [X] Add end-to-end tests
  - [x] Make debug logs optional for REPL or program execution
- - [ ] Improve error logs; print line and column
  - [ ] Add Panic Mode error recovery; stop crashing the compiler on every error.
+ - [ ] Improve error logs; print line and column
  - [ ] Implement objects / structs
- - [ ] Add garbage collector
  - [ ] Implement closures
+ - [ ] Add garbage collector
 
 ## v1.1 Tasks
  - [ ] Add native functions

--- a/README.md
+++ b/README.md
@@ -351,8 +351,7 @@ The following features are necessary a proper v1.0 release, in rough order:
  - [X] Implement functions and returns
  - [X] Add end-to-end tests
  - [x] Make debug logs optional for REPL or program execution
- - [ ] Add Panic Mode error recovery; stop crashing the compiler on every error.
- - [ ] Improve error logs; print line and column
+ - [X] Add Panic Mode error recovery to parser; stop crashing on every error.
  - [ ] Implement objects / structs
  - [ ] Implement closures
  - [ ] Add garbage collector
@@ -361,4 +360,6 @@ The following features are necessary a proper v1.0 release, in rough order:
  - [ ] Add native functions
  - [ ] Add benchmark tests
  - [ ] Profile execution and find opportunities for optimization
+ - [ ] Add Panic Mode error recovery to compiler
+ - [ ] Improve compiler error logging; print line and column
  - [ ] Implement [NaN boxing](https://piotrduperas.com/posts/nan-boxing)

--- a/code.sol
+++ b/code.sol
@@ -1,21 +1,6 @@
-print "Expecting 9 and 10 to be printed:";
-val f = lambda(b){ b+2; };
-print f(7);
-print f(8);
+// Errors (on purpose);
+val a = 2;
+va b = 3;
 
-das ds ads;
-
-print "";
-print "Expecting 5 and 25 to be printed:";
-val a = lambda(b, c){ print b+c; };
-a({2;}, 3);
-a({12;}, 13);
-
-print "";
-print "Expecting 12 and 16 to be printed:";
-val b = lambda(b, c){ b+c; };
-val c = lambda(d, e){
-    b(d, e) + 1;
-};
-print c(5, 6);
-print c(7,8);
+prin 2;
+print a;

--- a/code.sol
+++ b/code.sol
@@ -3,6 +3,8 @@ val f = lambda(b){ b+2; };
 print f(7);
 print f(8);
 
+das ds ads;
+
 print "";
 print "Expecting 5 and 25 to be printed:";
 val a = lambda(b, c){ print b+c; };

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 
 #include "bytecode.h"
+#include "error.h"
 #include "syntax.h"
 #include "token.h"
 #include "util/hash_table.h"
@@ -65,6 +66,7 @@ typedef struct {
     Source* ASTSource;                 // Root of the AST
     HashTable globals;                 // A hash table to keep track of globals to prevent redefinition and enforce constant `val`s.
     CompilerUnit currentCompilerUnit;  // The current compiler unit being executed.
+    ErrorArray errors;
 } CompilerState;
 
 /* Initialize a Compiler with an AST to be parsed */

--- a/src/error.c
+++ b/src/error.c
@@ -1,0 +1,30 @@
+#include "error.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "util/array.h"
+#include "util/colors.h"
+
+void initErrorArray(ErrorArray* errorArray) {
+    INIT_ARRAY((*errorArray), Error);
+}
+
+void addError(ErrorArray* errorArray, const char* message, Token token) {
+    Error error = {
+        .message = message,
+        .token = token};
+    INSERT_ARRAY((*errorArray), error, Error);
+}
+
+void printErrors(ErrorArray* errorArray) {
+    for (size_t i = 0; i < errorArray->used; i++) {
+        Error* error = &errorArray->values[i];
+        fprintf(stderr, KRED "Error" RESET " [line %d, column %d]: %s\n",
+                error->token.lineNo, error->token.colNo, error->message);
+    }
+}
+
+bool hadError(ErrorArray* errorArray) {
+    return errorArray->used > 0;
+}

--- a/src/error.c
+++ b/src/error.c
@@ -3,25 +3,81 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "util/array.h"
 #include "util/colors.h"
 
 void initErrorArray(ErrorArray* errorArray) {
     INIT_ARRAY((*errorArray), Error);
 }
 
-void addError(ErrorArray* errorArray, const char* message, Token token) {
+void addError(ErrorArray* errorArray, const char* message, Token token, ErrorType type) {
     Error error = {
         .message = message,
-        .token = token};
+        .token = token,
+        .type = type};
     INSERT_ARRAY((*errorArray), error, Error);
+}
+
+static char const* tokenTypeStrings[] = {
+    [SCANNER_ERROR] = "ScannerError",
+    [PARSER_ERROR] = "ParserError",
+    [COMPILER_ERROR] = "CompilerError",
+};
+
+void printErrorMessage(Error* error) {
+    const char* errorType = tokenTypeStrings[error->type];
+
+    fprintf(stderr, KRED "%s" RESET KGRY "[%d:%d]" RESET, errorType, error->token.lineNo, error->token.colNo);
+
+    if (error->token.type == TOKEN_EOF) {
+        fprintf(stderr, " at end");
+    } else if (error->token.type != TOKEN_ERROR) {
+        fprintf(stderr, " at '%.*s'", error->token.length, error->token.start);
+    }
+
+    fprintf(stderr, ": %s\n", error->message);
+}
+
+/**
+ * Using the Token in the Error, print the line of source code where the error
+ * occurred, plus a carat indicating the location of the error.
+ *
+ * This function is rudimentary and not super efficient, but that's ok because
+ * errors are not abundant and fast compilation speed is not one of SolScript's goals.
+ */
+static void printSourceLine(Error* error) {
+    // Find the beginning of the line
+    const char* lineStart = error->token.start;
+    while (lineStart > (error->token.start - error->token.colNo + error->token.length + 1) && lineStart[-1] != '\n') {
+        lineStart--;
+    }
+
+    // Find the end of the line
+    const char* lineEnd = error->token.start;
+    while (*lineEnd != '\0' && *lineEnd != '\n' && *lineEnd != EOF) {
+        lineEnd++;
+    }
+
+    // Print the line
+    int lineLength = lineEnd - lineStart;
+    if (lineLength > 0) {
+        fprintf(stderr, "    %.*s\n", lineLength, lineStart);
+    } else {
+        fprintf(stderr, "    <empty line>\n");
+    }
+
+    // Print the caret
+    for (int i = 0; i < (error->token.start - lineStart) + 4; i++) {
+        fprintf(stderr, " ");
+    }
+    fprintf(stderr, "^\n");
 }
 
 void printErrors(ErrorArray* errorArray) {
     for (size_t i = 0; i < errorArray->used; i++) {
         Error* error = &errorArray->values[i];
-        fprintf(stderr, KRED "Error" RESET " [line %d, column %d]: %s\n",
-                error->token.lineNo, error->token.colNo, error->message);
+        printErrorMessage(error);
+        printSourceLine(error);
+        fprintf(stderr, "\n");
     }
 }
 

--- a/src/error.h
+++ b/src/error.h
@@ -27,9 +27,6 @@ typedef struct {
 /**
  * An array of compile-time errors. This struct can be used by the
  * scanner, parser, or compiler, but it shouldn't be shared across them.
- *
- * A pointer to the source code is required so the line where the error
- * occurred can be printed.
  */
 typedef struct {
     Error* values;

--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,37 @@
+#ifndef sol_script_error_h
+#define sol_script_error_h
+
+#include <stdbool.h>
+
+#include "token.h"
+#include "util/array.h"
+
+/**
+ * Struct to represent a compile-time error, which could come from the
+ * scanner, parser, or compiler.
+ *
+ * The Token contains the location (line, column) of the error.
+ */
+typedef struct {
+    const char* message;
+    Token token;
+} Error;
+
+/**
+ * An array of compile-time errors. This struct can be used by the
+ * scanner, parser, or compiler, but it shouldn't be shared across them.
+ *
+ * The Token contains the location (line, column) of the error.
+ */
+typedef struct {
+    Error* values;
+    size_t used;
+    size_t size;
+} ErrorArray;
+
+void initErrorArray(ErrorArray* errorArray);
+void addError(ErrorArray* errorArray, const char* message, Token token);
+void printErrors(ErrorArray* errorArray);
+void freeErrorArray(ErrorArray* errorArray);
+
+#endif

--- a/src/error.h
+++ b/src/error.h
@@ -6,6 +6,12 @@
 #include "token.h"
 #include "util/array.h"
 
+typedef enum {
+    SCANNER_ERROR,
+    PARSER_ERROR,
+    COMPILER_ERROR,
+} ErrorType;
+
 /**
  * Struct to represent a compile-time error, which could come from the
  * scanner, parser, or compiler.
@@ -15,13 +21,15 @@
 typedef struct {
     const char* message;
     Token token;
+    ErrorType type;
 } Error;
 
 /**
  * An array of compile-time errors. This struct can be used by the
  * scanner, parser, or compiler, but it shouldn't be shared across them.
  *
- * The Token contains the location (line, column) of the error.
+ * A pointer to the source code is required so the line where the error
+ * occurred can be printed.
  */
 typedef struct {
     Error* values;
@@ -30,8 +38,9 @@ typedef struct {
 } ErrorArray;
 
 void initErrorArray(ErrorArray* errorArray);
-void addError(ErrorArray* errorArray, const char* message, Token token);
+void addError(ErrorArray* errorArray, const char* message, Token token, ErrorType type);
 void printErrors(ErrorArray* errorArray);
 void freeErrorArray(ErrorArray* errorArray);
+bool hadError(ErrorArray* errorArray);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -39,16 +39,13 @@ static void repl() {
         ASTParser treeParser;
 
         TokenArray tokens = scanTokensFromString(&scanner, input);
-        printTokenList(tokens);
 
         Source* source = parseASTFromTokens(&treeParser, &tokens);
-        printAST(source);
 
         // Reset compiled bytecode and feed new AST, but maintain same constant pool
         INIT_ARRAY(compiler.currentCompilerUnit.compiledCodeObject.bytecodeArray, Bytecode);
         compiler.ASTSource = source;
         CompiledCode newCode = compile(&compiler);
-        printCompiledCode(newCode);
 
         // Add new bytecode to VM
         for (int i = 0; i < newCode.topLevelCodeObject.bytecodeArray.used; i++) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -105,7 +105,7 @@ static void checkSemicolonAfterExpression(ASTParser* parser, Expression* maybeLa
 
 /**
  * Recover from an error. Skip tokens until we finds a synchronization point, which
- * is as the next.
+ * we define as being the start of the next statement.
  */
 static void synchronizeAfterError(ASTParser* parser) {
     advance(parser);

--- a/src/parser.h
+++ b/src/parser.h
@@ -2,6 +2,7 @@
 #define sol_script_tree_parser_h
 
 #include "array.h"
+#include "error.h"
 #include "token.h"
 
 // These are the types of syntax nodes SolScript has. We use it
@@ -16,14 +17,16 @@ typedef enum {
  *
  * @param tokenArray Array of tokens generated from the scanner.
  * @param current Current token. 0-indexed.
+ * @param previous The token just consumed.
  * @param source Root of the AST.
+ * @param errors Errors that occurred during parsing.
  * */
 typedef struct {
-    // Inputs from scanner
     TokenArray tokenArray;
-    Token* current;   // the token to be consumed next
-    Token* previous;  // the token just consumed
-    Source* source;   // Root of the AST
+    Token* current;
+    Token* previous;
+    Source* source;
+    ErrorArray errors;
 } ASTParser;
 
 /**

--- a/src/parser.h
+++ b/src/parser.h
@@ -51,10 +51,14 @@ Source* parseASTFromTokens(ASTParser* treeParser, TokenArray* tokenArray);
 
 /**
  * Free memory allocated for the Source of an AST.
- *
- * @param source the Source to free.
  */
 void freeSource(Source* source);
+
+/**
+ * Free memory allocated to the AST parser, but NOT its compiled AST.
+ * Use freeSource to free the AST.
+ */
+void freeParser(ASTParser* parser);
 
 /**
  *  Initialize treeParser at the beginning of the given token array to be parsed.

--- a/test/end_to_end/utils.h
+++ b/test/end_to_end/utils.h
@@ -15,9 +15,9 @@ void execute_solscript(const char* sourceCode) {
     TokenArray tokens = scanTokens(&scanner);
 
     // Parse the tokens into an Abstract Syntax Tree
-    ASTParser treeParser;
-    initASTParser(&treeParser, tokens);
-    Source* source = parseAST(&treeParser);
+    ASTParser parser;
+    initASTParser(&parser, tokens);
+    Source* source = parseAST(&parser);
 
     // Compile the AST into bytecode
     CompilerState compiler;
@@ -32,5 +32,6 @@ void execute_solscript(const char* sourceCode) {
     // Clean up
     freeCompilerState(&compiler);
     freeSource(source);
+    freeParser(&parser);
     FREE_ARRAY(tokens);
 }

--- a/test/manual/errors/parser_panic_mode_recovery.sol
+++ b/test/manual/errors/parser_panic_mode_recovery.sol
@@ -1,0 +1,6 @@
+// Errors (on purpose);
+val a = 2;
+va b = 3;
+
+prin 2;
+print a;

--- a/test/unit/src/parser_test.c
+++ b/test/unit/src/parser_test.c
@@ -95,6 +95,7 @@ int test_parser_simple_expression() {
 
     // Clean up
     freeSource(source);
+    freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -110,6 +111,7 @@ int test_parser_print_statement() {
 
     FREE_ARRAY(tokens);
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -152,6 +154,7 @@ int test_parser_logical_or_expression() {
     ASSERT(strcmp(rightPrimary->literal->as.booleanLiteral->token.start, "false") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -192,6 +195,7 @@ int test_parser_logical_and_expression() {
     ASSERT(strcmp(rightPrimary->literal->as.booleanLiteral->token.start, "true") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -232,6 +236,7 @@ int test_parser_equality_expression() {
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "5") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -271,6 +276,7 @@ int test_parser_comparison_expression() {
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "5") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -310,6 +316,7 @@ int test_parser_multiplicative_expression() {
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "2") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -343,6 +350,7 @@ int test_parser_unary_expression() {
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "1") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -372,6 +380,7 @@ int test_parser_boolean_literal() {
     ASSERT(strcmp(primaryExpr->literal->as.booleanLiteral->token.start, "true") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -471,6 +480,7 @@ int test_parser_complex_expression() {
     ASSERT(strcmp(subRightPrimary->literal->as.numberLiteral->token.start, "2") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -516,6 +526,7 @@ int test_parser_nested_parentheses_expression() {
 
     // Cleanup
     freeSource(source);
+    freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -564,6 +575,7 @@ int test_parser_variable_declaration_and_reading() {
 
     // Cleanup
     freeSource(source);
+    freeParser(&parser);
     FREE_ARRAY(tokens);
 
     return SUCCESS_RETURN_CODE;
@@ -597,6 +609,7 @@ int test_parser_string_literal() {
 
     // Cleanup
     freeSource(source);
+    freeParser(&parser);
     FREE_ARRAY(tokens);
 
     return SUCCESS_RETURN_CODE;
@@ -638,6 +651,7 @@ int test_parser_block_statement() {
 
     // Cleanup
     freeSource(source);
+    freeParser(&parser);
     FREE_ARRAY(tokens);
     return SUCCESS_RETURN_CODE;
 }
@@ -666,6 +680,7 @@ int test_parser_if_statement_true_branch_only() {
     ASSERT(strcmp(printStmt->expression->as.primaryExpression->literal->as.stringLiteral->token.start, "\"Hello, World!\"") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     FREE_ARRAY(tokens);
     return SUCCESS_RETURN_CODE;
 }
@@ -697,6 +712,7 @@ int test_parser_if_statement_with_else_branch() {
     ASSERT(strcmp(falsePrintStmt->expression->as.primaryExpression->literal->as.stringLiteral->token.start, "\"Goodbye, World!\"") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     FREE_ARRAY(tokens);
     return SUCCESS_RETURN_CODE;
 }
@@ -735,6 +751,7 @@ int test_parser_block_expression_simple() {
     ASSERT(strcmp(blockExpr->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -783,6 +800,7 @@ int test_parser_block_expression_nested() {
     ASSERT(strcmp(innerBlockExpr->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -827,6 +845,7 @@ int test_parser_block_expression_with_statements() {
     ASSERT(strcmp(blockExpr->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -890,6 +909,7 @@ int test_parser_block_expression_as_if_condition() {
     ASSERT(trueBlock->statementArray.values[0]->type == PRINT_STATEMENT);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -917,6 +937,7 @@ int test_parser_var_declaration() {
     ASSERT(varDecl->maybeExpression == NULL);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -949,6 +970,7 @@ int test_parser_var_declaration_with_initializer() {
     ASSERT(strcmp(varDecl->maybeExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "42") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -982,6 +1004,7 @@ int test_parser_assignment() {
     ASSERT(strcmp(assignmentStmt->value->as.primaryExpression->literal->as.numberLiteral->token.start, "2") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1013,6 +1036,7 @@ int test_parser_iteration_statement_no_curlys() {
     ASSERT(iterStmt->bodyStatement->type == PRINT_STATEMENT);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1042,6 +1066,7 @@ int test_parser_iteration_statement_no_parentheses_no_curlys() {
     ASSERT(iterStmt->bodyStatement->type == PRINT_STATEMENT);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1080,6 +1105,7 @@ int test_parser_iteration_statement_with_block() {
     ASSERT(iterStmt->bodyStatement->as.blockStatement->statementArray.used == 2);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1119,6 +1145,7 @@ int test_parser_lambda_expression_no_parameters() {
     ASSERT(strcmp(lambdaExpr->bodyBlock->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "42") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1160,6 +1187,7 @@ int test_parser_lambda_expression_single_parameter() {
     ASSERT(strcmp(lambdaExpr->bodyBlock->lastExpression->as.primaryExpression->literal->as.identifierLiteral->token.start, "x") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1204,6 +1232,7 @@ int test_parser_lambda_expression_multiple_parameters() {
     ASSERT(lambdaExpr->bodyBlock->lastExpression->type == ADDITIVE_EXPRESSION);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1246,6 +1275,7 @@ int test_parser_lambda_expression_no_last_expression_in_block() {
     ASSERT(lambdaExpr->bodyBlock->lastExpression == NULL);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1312,6 +1342,7 @@ int test_parser_call_with_args() {
     ASSERT(callBob->as.expressionStatement->expression->as.callExpression->arguments->used == 1);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1368,6 +1399,7 @@ int test_parser_call_in_binary_expression() {
     ASSERT(strcmp(addExpr->as.additiveExpression->rightExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "10") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1410,6 +1442,7 @@ int test_parser_call_no_args() {
     ASSERT(callExpr->as.callExpression->arguments->used == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1479,6 +1512,7 @@ int test_parser_recursive_call() {
     ASSERT(recursiveCallExpr->as.multiplicativeExpression->rightExpression->as.callExpression->arguments->used == 1);
 
     freeSource(source);
+    freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -1545,6 +1579,7 @@ int test_parser_call_with_block_expression_arg() {
     ASSERT(callExpr->as.callExpression->arguments->values[1]->type == LAMBDA_EXPRESSION);
 
     freeSource(source);
+    freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -1622,6 +1657,7 @@ int test_parser_nested_calls() {
     ASSERT(strcmp(callAddTwo->as.callExpression->arguments->values[0]->as.primaryExpression->literal->as.numberLiteral->token.start, "5") == 0);
 
     freeSource(source);
+    freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -1707,6 +1743,7 @@ int test_parser_call_with_expression_args() {
     ASSERT(strcmp(secondArg->as.additiveExpression->rightExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
 
     freeSource(source);
+    freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -1775,6 +1812,7 @@ int test_parser_call_in_if_condition() {
     ASSERT(strcmp(conditionExpr->as.callExpression->arguments->values[0]->as.primaryExpression->literal->as.identifierLiteral->token.start, "num") == 0);
 
     freeSource(source);
+    freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -1803,6 +1841,7 @@ int test_parser_simple_return() {
     ASSERT(strcmp(returnStmt->expression->as.primaryExpression->literal->as.numberLiteral->token.start, "42") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1827,6 +1866,7 @@ int test_parser_return_without_expression() {
     ASSERT(returnStmt->expression == NULL);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1870,6 +1910,7 @@ int test_parser_return_in_lambda() {
     ASSERT(strcmp(returnStmt->expression->as.primaryExpression->literal->as.numberLiteral->token.start, "10") == 0);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1937,5 +1978,6 @@ int test_parser_multiple_returns() {
     ASSERT(falseBlock->statementArray.values[0]->type == RETURN_STATEMENT);
 
     freeSource(source);
+    freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }


### PR DESCRIPTION
### Summary
Add panic mode error recovery to Parser.

This means that the parser will no longer exit on errors. Instead, it will move to the statement and continue. Errors will be reported in batch after the whole code is parsed.

### Testing
Added a `.sol` test and manually confirmed it works:

Code:
```
// Errors (on purpose);
val a = 2;
va b = 3;

prin 2;
print a;
```

Execution:
```
% make clean && make && ./sol test/manual/errors/parser_panic_mode_recovery.sol      
...
ParserError[3:6] at 'b': Expected ';' after expression-statement.
    va b = 3;
       ^

ParserError[5:8] at '2': Expected ';' after expression-statement.
    prin 2;
         ^

CompilerError. Identifier 'va' referenced before declaration.
```