### PR TITLE
Fix chained function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,9 +316,10 @@ Additionally, run time performance is more critical than compilation time perfor
 `test/sol/` - tests written in SolScript
 
 
-## v1.0 Release Tracker
+## Release Tracker
 
-The following features are necessary a proper v1.0 release, in rough order:
+## v1.0 
+To-do before v1.0 is released:
 
  - [x] Design the lexical grammar
  - [x] Design the syntax grammar
@@ -352,10 +353,18 @@ The following features are necessary a proper v1.0 release, in rough order:
  - [ ] Implement closures
  - [ ] Add garbage collector
 
-## v1.1 Tasks
+### v1.1 Tasks
+These tasks are outside the scope of v1:
+
  - [ ] Add native functions
  - [ ] Add benchmark tests
  - [ ] Profile execution and find opportunities for optimization
  - [ ] Add Panic Mode error recovery to compiler
  - [ ] Improve compiler error logging; print line and column
  - [ ] Implement [NaN boxing](https://piotrduperas.com/posts/nan-boxing)
+
+### Small Fixes To implement
+These are smaller-ish items to do at any time:
+
+- [ ] If-expressions at the end of function blocks should be used as function return.
+- [ ] Get recursive functions working

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ TOKEN_EOF(lexeme="", line=2, column=2)
 
 ### Syntactical Grammar
 
-The syntactical grammar _should_ be an LALR(2) grammar, i.e. it can be parsed by a left-to-right parser with 2 tokens of look-ahead. In SolScript, a program Source is a series of Statements. Statements use Expressions and Literals. Expressions are evaluated to a Value at run time.
+The syntactical grammar _should_ be an LALR(1) grammar, i.e. it can be parsed by a left-to-right parser with 2 tokens of look-ahead. In SolScript, a program Source is a series of Statements. Statements use Expressions and Literals. Expressions are evaluated to a Value at run time.
 
 This grammar is primarily inspired by the [ANSI C grammar](https://slebok.github.io/zoo/c/c90/sdf/extracted/index.html#Statement), [Lox](https://craftinginterpreters.com/) and Scala.
 
@@ -219,15 +219,10 @@ unary-expression:
   ( "-" )* postfix-expression
 
 postfix-expression:
-  postfix-call-expression
-  postfix-call-expression "." postfix-expression
-  "this" "." postfix-expression
-  identifier "." postfix-expression
-
-postfix-call-expression:
   primary-expression
-  identifier "(" ")"  
-  identifier "(" argument-list ")"  
+  postfix-expression "(" ")"
+  postfix-expression "(" argument-list ")"
+  postfix-expression "." identifier
 
 primary-expression:
   number-literal
@@ -238,6 +233,7 @@ primary-expression:
   "true"
   "false"
   "null"
+  "this"
 
 
 number-literal      # terminal

--- a/README.md
+++ b/README.md
@@ -366,5 +366,6 @@ These tasks are outside the scope of v1:
 ### Small Fixes To implement
 These are smaller-ish items to do at any time:
 
+- [X] Fix chained function calls
 - [ ] If-expressions at the end of function blocks should be used as function return.
 - [ ] Get recursive functions working

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # SolScript
 
-SolScript is an interpreted, stack-based, prototype-based, garbage-collected programming language.
+SolScript is an interpreted, stack-based programming language. Its syntax draws from Scala and C, and its internal virtual machine is inspired by Python and the JVM.
 
-To get started, clone the repository, run `make` to build the project or `make debug` to include debug logs. Run `./sol` to start the REPL or `./sol program.sol` execute a SolScript program.
+To begin using SolScript, clone the repository and build the project by running `make`. For additional debugging information, use `make debug`. Once built, you can start the REPL by executing `./sol`, or run a SolScript program with `./sol program.sol`.
 
-
-**Important:** SolScript is a [work in progress](https://github.com/CaioCamatta/sol-script?tab=readme-ov-file#v10-release-tracker).
+**Important:** Please note that SolScript is currently [a work in progress](https://github.com/CaioCamatta/sol-script?tab=readme-ov-file#v10) and has only been tested on ARM-based macOS systems.
 
 
 ## Example program

--- a/code.sol
+++ b/code.sol
@@ -1,6 +1,5 @@
-// Errors (on purpose);
-val a = 2;
-va b = 3;
+val a = lambda() {
+    lambda() {print "here";};
+};
 
-prin 2;
-print a;
+a()();

--- a/src/debug.c
+++ b/src/debug.c
@@ -286,14 +286,8 @@ static void printExpression(const Expression* expression, int depth) {
         case CALL_EXPRESSION: {
             CallExpression* callExpr = expression->as.callExpression;
             printf("CallExpression" KGRY "(numberOfArguments=%hhu)\n" RESET, callExpr->arguments->used);
-            printIndent(depth + 1);
-            printf("FunctionName\n");
 
-            Literal* tempLiteral = (Literal*)malloc(sizeof(Literal));
-            tempLiteral->type = IDENTIFIER_LITERAL;
-            tempLiteral->as.identifierLiteral = callExpr->lambdaFunctionName;
-            printLiteral(tempLiteral, depth + 2);
-            free(tempLiteral);
+            printExpression(callExpr->leftHandSide, depth + 1);
 
             printIndent(depth + 1);
             printf("Arguments" KGRY "(numberOfArguments=%hhu)\n" RESET, callExpr->arguments->used);

--- a/src/parser.c
+++ b/src/parser.c
@@ -314,7 +314,6 @@ static ExpressionArray* argumentList(ASTParser* parser) {
  *  postfix-expression "(" ")"
  *  postfix-expression "(" argument-list ")"
  *  postfix-expression "." identifier
- *  "this" "." postfix-expression
  *
  * Note: postfixExpression() is slightly different than other parsing functions because it can return
  * different types of AST nodes (e.g. CallExpression, MemberExpression). This is fine; Sol combines its

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -25,6 +25,7 @@ typedef struct UnaryExpression UnaryExpression;
 typedef struct PrimaryExpression PrimaryExpression;
 typedef struct LambdaExpression LambdaExpression;
 typedef struct CallExpression CallExpression;
+typedef struct MemberExpression MemberExpression;
 typedef struct BooleanLiteral BooleanLiteral;
 typedef struct NumberLiteral NumberLiteral;
 typedef struct IdentifierLiteral IdentifierLiteral;
@@ -51,18 +52,19 @@ typedef enum {
     COMPARISON_EXPRESSION,      // Stack effect: -1
     ADDITIVE_EXPRESSION,        // Stack effect: -1
     MULTIPLICATIVE_EXPRESSION,  // Stack effect: -1
-    BLOCK_EXPRESSION,           // Stack effect: 0 per se
+    BLOCK_EXPRESSION,           // Stack effect: 1
     UNARY_EXPRESSION,           // Stack effect: 0
-    PRIMARY_EXPRESSION,         // Stack effect: 0 per se
+    PRIMARY_EXPRESSION,         // Stack effect: 0
     LAMBDA_EXPRESSION,          // Stack effect: 1
-    CALL_EXPRESSION             // Stack effect: 1
+    CALL_EXPRESSION,            // Stack effect: 1
+    MEMBER_EXPRESSION           // Stack effect: 0
 } ExpressionType;
 
 typedef enum {
-    BOOLEAN_LITERAL,     // Stack effect: +1
-    NUMBER_LITERAL,      // Stack effect: +1
-    IDENTIFIER_LITERAL,  // Stack effect: +1
-    STRING_LITERAL       // Stack effect: +1
+    BOOLEAN_LITERAL,     // Stack effect: 1
+    NUMBER_LITERAL,      // Stack effect: 1
+    IDENTIFIER_LITERAL,  // Stack effect: 1
+    STRING_LITERAL       // Stack effect: 1
 } LiteralType;
 
 // --- Abstract productions ---
@@ -95,6 +97,7 @@ typedef struct {
         PrimaryExpression *primaryExpression;
         LambdaExpression *lambdaExpression;
         CallExpression *callExpression;
+        MemberExpression *memberExpression;
     } as;
 } Expression;
 
@@ -224,8 +227,12 @@ typedef struct {
 } ExpressionArray;
 
 struct CallExpression {
-    IdentifierLiteral *lambdaFunctionName;
+    Expression *leftHandSide;
     ExpressionArray *arguments;  // May be an empty array
+};
+struct MemberExpression {
+    Expression *leftHandSide;
+    Expression *rightHandSide;
 };
 
 struct BooleanLiteral {

--- a/src/vm.c
+++ b/src/vm.c
@@ -43,7 +43,7 @@ static void runtimeError(CallFrame* callframe, const char* format, ...) {
     va_start(args, format);
     fprintf(stderr, KRED);
     vfprintf(stderr, format, args);
-    fprintf(stderr, RESET);
+    fprintf(stderr, RESET "\n");
     va_end(args);
 
     // TODO: make this not exit during a REPL session.

--- a/test/end_to_end/scenarios.c
+++ b/test/end_to_end/scenarios.c
@@ -275,18 +275,18 @@ static int test_functions_single_parameter() {
     EXPECT("5.000000\nhello");
 }
 
-static int test_functions_recursive() {
-    SCENARIO(
-        "val factorial = lambda (n) {"
-        "    if (n <= 1) {"
-        "        1;"
-        "    } else {"
-        "        n * factorial(n - 1);"
-        "    };"
-        "};"
-        "print factorial(5);");
-    EXPECT("120.000000");
-}
+// static int test_functions_recursive() {
+//     SCENARIO(
+//         "val factorial = lambda (n) {"
+//         "    if (n <= 1) {"
+//         "        1;"
+//         "    } else {"
+//         "        n * factorial(n - 1);"
+//         "    };"
+//         "};"
+//         "print factorial(5);");
+//     EXPECT("120.000000");
+// }
 
 static int test_functions_modify_global() {
     SCENARIO(
@@ -346,12 +346,12 @@ static int test_functions_lambda_as_argument() {
     EXPECT("10.000000");
 }
 
-static int test_functions_if_statement_in_lambda() {
-    SCENARIO(
-        "val calculate = lambda (x) { val result = x * 2; if (result > 10) { result + 1; } else { result - 1; } };"
-        "print calculate(6);");
-    EXPECT("13.000000");
-}
+// static int test_functions_if_statement_in_lambda() {
+//     SCENARIO(
+//         "val calculate = lambda (x) { val result = x * 2; if (result > 10) { result + 1; } else { result - 1; } };"
+//         "print calculate(6);");
+//     EXPECT("13.000000");
+// }
 
 static int test_functions_return_in_if_statement() {
     SCENARIO(
@@ -418,6 +418,13 @@ static int test_functions_immediately_invoked() {
         ""); // Should produce an error or unexpected behavior
 }
 */
+
+static int test_functions_chained_calls() {
+    SCENARIO(
+        "val makePrinter = lambda() { lambda(strToPrint) { print strToPrint; }; };"
+        "makePrinter()(\"Success\");");
+    EXPECT("Success")
+}
 
 static int test_if_statements_multiple_ifs() {
     SCENARIO(

--- a/test/end_to_end/test.c
+++ b/test/end_to_end/test.c
@@ -42,6 +42,7 @@ void all_end_to_end_tests() {
     RUN_TEST(test_functions_nested_calls);
     // RUN_TEST(test_functions_if_statement_in_lambda); -- Needs to be fixed
     // RUN_TEST(test_functions_recursive); -- Needs to be fixed
+    RUN_TEST(test_functions_chained_calls);
 
     /* If statements */
     RUN_TEST(test_if_statements_multiple_ifs);

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -1527,6 +1527,66 @@ int test_compiler_call_expression_nested() {
     return SUCCESS_RETURN_CODE;
 }
 
+int test_compiler_chained_calls() {
+    Source testSource = {
+        .rootStatements = {
+            VAL_DECLARATION_STATEMENT(
+                "add",
+                LAMBDA_EXPRESSION(
+                    IDENTIFIER_ARRAY(
+                        {.token = IDENTIFIER_TOKEN("a")},
+                        {.token = IDENTIFIER_TOKEN("b")}),
+                    ADDITIVE_EXPRESSION(
+                        PRIMARY_EXPRESSION(IDENTIFIER_LITERAL("a")),
+                        TOKEN(TOKEN_PLUS),
+                        PRIMARY_EXPRESSION(IDENTIFIER_LITERAL("b"))))),
+            EXPRESSION_STATEMENT(
+                CALL_EXPRESSION(
+                    CALL_EXPRESSION(
+                        CALL_EXPRESSION(
+                            PRIMARY_EXPRESSION(IDENTIFIER_LITERAL("add")),
+                            EXPRESSION_ARRAY(
+                                PRIMARY_EXPRESSION(NUMBER_LITERAL("1")),
+                                PRIMARY_EXPRESSION(NUMBER_LITERAL("2")))),
+                        EXPRESSION_ARRAY(
+                            PRIMARY_EXPRESSION(NUMBER_LITERAL("3")),
+                            PRIMARY_EXPRESSION(NUMBER_LITERAL("4")))),
+                    EXPRESSION_ARRAY(
+                        PRIMARY_EXPRESSION(NUMBER_LITERAL("5")),
+                        PRIMARY_EXPRESSION(NUMBER_LITERAL("6")))))},
+        .numberOfStatements = 2,
+    };
+
+    COMPILE_TEST_SOURCE
+
+    // Verify the constant pool
+    ASSERT(compiledCode.topLevelCodeObject.constantPool.used == 8);  // 'add', 1, 2, 3, 4, 5, 6
+    ASSERT(compiledCode.topLevelCodeObject.constantPool.values[0].type == CONST_TYPE_LAMBDA);
+    ASSERT(strcmp(compiledCode.topLevelCodeObject.constantPool.values[1].as.string, "add") == 0);
+    for (int i = 2; i <= 7; i++) {
+        ASSERT(compiledCode.topLevelCodeObject.constantPool.values[i].type == CONST_TYPE_DOUBLE);
+    }
+
+    // Verify the bytecode for the chained function calls
+    ASSERT(compiledCode.topLevelCodeObject.bytecodeArray.values[0].type == OP_LAMBDA);             // 'add'
+    ASSERT(compiledCode.topLevelCodeObject.bytecodeArray.values[1].type == OP_DEFINE_GLOBAL_VAL);  // 'add'
+    ASSERT(compiledCode.topLevelCodeObject.bytecodeArray.values[2].type == OP_LOAD_CONSTANT);      // 1
+    ASSERT(compiledCode.topLevelCodeObject.bytecodeArray.values[3].type == OP_LOAD_CONSTANT);      // 2
+    ASSERT(compiledCode.topLevelCodeObject.bytecodeArray.values[4].type == OP_LOAD_CONSTANT);      // 3
+    ASSERT(compiledCode.topLevelCodeObject.bytecodeArray.values[5].type == OP_LOAD_CONSTANT);      // 4
+    ASSERT(compiledCode.topLevelCodeObject.bytecodeArray.values[6].type == OP_LOAD_CONSTANT);      // 5
+    ASSERT(compiledCode.topLevelCodeObject.bytecodeArray.values[7].type == OP_LOAD_CONSTANT);      // 6
+    ASSERT(compiledCode.topLevelCodeObject.bytecodeArray.values[8].type == OP_GET_GLOBAL_VAL);
+    ASSERT(compiledCode.topLevelCodeObject.bytecodeArray.values[9].type == OP_CALL);
+    ASSERT(compiledCode.topLevelCodeObject.bytecodeArray.values[10].type == OP_CALL);
+    ASSERT(compiledCode.topLevelCodeObject.bytecodeArray.values[11].type == OP_CALL);
+    ASSERT(compiledCode.topLevelCodeObject.bytecodeArray.values[12].type == OP_POPN);
+
+    FREE_COMPILER
+
+    return SUCCESS_RETURN_CODE;
+}
+
 int test_compiler_lambda_with_return() {
     Source testSource = {
         .rootStatements = {

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -279,14 +279,13 @@
         }                                                                 \
     }
 
-#define CALL_EXPRESSION(functionName, argumentsArg)                                                                 \
-    &(Expression) {                                                                                                 \
-        .type = CALL_EXPRESSION,                                                                                    \
-        .as.callExpression = &(CallExpression) {                                                                    \
-            .lambdaFunctionName = &(IdentifierLiteral){                                                             \
-                .token = (Token){.type = TOKEN_IDENTIFIER, .start = functionName, .length = strlen(functionName)}}, \
-            .arguments = argumentsArg                                                                               \
-        }                                                                                                           \
+#define CALL_EXPRESSION(leftHandSideExpr, argumentsArg) \
+    &(Expression) {                                     \
+        .type = CALL_EXPRESSION,                        \
+        .as.callExpression = &(CallExpression) {        \
+            .leftHandSide = (leftHandSideExpr),         \
+            .arguments = (argumentsArg)                 \
+        }                                               \
     }
 
 // Helper macro for creating IdentifierArray
@@ -1439,7 +1438,7 @@ int test_compiler_call_expression_simple() {
             VAL_DECLARATION_STATEMENT(
                 "result",
                 CALL_EXPRESSION(
-                    "add",
+                    PRIMARY_EXPRESSION(IDENTIFIER_LITERAL("add")),
                     EXPRESSION_ARRAY(
                         PRIMARY_EXPRESSION(NUMBER_LITERAL("5")),
                         PRIMARY_EXPRESSION(NUMBER_LITERAL("3")))))},
@@ -1492,10 +1491,10 @@ int test_compiler_call_expression_nested() {
                         PRIMARY_EXPRESSION(IDENTIFIER_LITERAL("b"))))),
             VAL_DECLARATION_STATEMENT(
                 "result",
-                CALL_EXPRESSION("add",
+                CALL_EXPRESSION(PRIMARY_EXPRESSION(IDENTIFIER_LITERAL("add")),
                                 EXPRESSION_ARRAY(
                                     PRIMARY_EXPRESSION(NUMBER_LITERAL("5")),
-                                    CALL_EXPRESSION("multiply",
+                                    CALL_EXPRESSION(PRIMARY_EXPRESSION(IDENTIFIER_LITERAL("multiply")),
                                                     EXPRESSION_ARRAY(
                                                         PRIMARY_EXPRESSION(NUMBER_LITERAL("3")),
                                                         PRIMARY_EXPRESSION(NUMBER_LITERAL("2")))))))},

--- a/test/unit/src/parser_test.c
+++ b/test/unit/src/parser_test.c
@@ -1332,13 +1332,13 @@ int test_parser_call_with_args() {
     Statement* callAlice = source->rootStatements[1];
     ASSERT(callAlice->type == EXPRESSION_STATEMENT);
     ASSERT(callAlice->as.expressionStatement->expression->type == CALL_EXPRESSION);
-    ASSERT(strcmp(callAlice->as.expressionStatement->expression->as.callExpression->lambdaFunctionName->token.start, "greet") == 0);
+    ASSERT(strcmp(callAlice->as.expressionStatement->expression->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "greet") == 0);
     ASSERT(callAlice->as.expressionStatement->expression->as.callExpression->arguments->used == 1);
 
     Statement* callBob = source->rootStatements[2];
     ASSERT(callBob->type == EXPRESSION_STATEMENT);
     ASSERT(callBob->as.expressionStatement->expression->type == CALL_EXPRESSION);
-    ASSERT(strcmp(callBob->as.expressionStatement->expression->as.callExpression->lambdaFunctionName->token.start, "greet") == 0);
+    ASSERT(strcmp(callBob->as.expressionStatement->expression->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "greet") == 0);
     ASSERT(callBob->as.expressionStatement->expression->as.callExpression->arguments->used == 1);
 
     freeSource(source);
@@ -1392,7 +1392,7 @@ int test_parser_call_in_binary_expression() {
     Expression* addExpr = valResult->as.valDeclarationStatement->expression;
     ASSERT(addExpr->type == ADDITIVE_EXPRESSION);
     ASSERT(addExpr->as.additiveExpression->leftExpression->type == CALL_EXPRESSION);
-    ASSERT(strcmp(addExpr->as.additiveExpression->leftExpression->as.callExpression->lambdaFunctionName->token.start, "double") == 0);
+    ASSERT(strcmp(addExpr->as.additiveExpression->leftExpression->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "double") == 0);
     ASSERT(addExpr->as.additiveExpression->leftExpression->as.callExpression->arguments->used == 1);
     ASSERT(addExpr->as.additiveExpression->rightExpression->type == PRIMARY_EXPRESSION);
     ASSERT(addExpr->as.additiveExpression->rightExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
@@ -1438,7 +1438,7 @@ int test_parser_call_no_args() {
 
     Expression* callExpr = callMyFunc->as.expressionStatement->expression;
     ASSERT(callExpr->type == CALL_EXPRESSION);
-    ASSERT(strcmp(callExpr->as.callExpression->lambdaFunctionName->token.start, "myFunc") == 0);
+    ASSERT(strcmp(callExpr->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "myFunc") == 0);
     ASSERT(callExpr->as.callExpression->arguments->used == 0);
 
     freeSource(source);
@@ -1508,7 +1508,7 @@ int test_parser_recursive_call() {
     Expression* recursiveCallExpr = ifStmt->as.selectionStatement->falseStatement->as.blockStatement->statementArray.values[0]->as.expressionStatement->expression;
     ASSERT(recursiveCallExpr->type == MULTIPLICATIVE_EXPRESSION);
     ASSERT(recursiveCallExpr->as.multiplicativeExpression->rightExpression->type == CALL_EXPRESSION);
-    ASSERT(strcmp(recursiveCallExpr->as.multiplicativeExpression->rightExpression->as.callExpression->lambdaFunctionName->token.start, "factorial") == 0);
+    ASSERT(strcmp(recursiveCallExpr->as.multiplicativeExpression->rightExpression->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "factorial") == 0);
     ASSERT(recursiveCallExpr->as.multiplicativeExpression->rightExpression->as.callExpression->arguments->used == 1);
 
     freeSource(source);
@@ -1574,7 +1574,7 @@ int test_parser_call_with_block_expression_arg() {
 
     Expression* callExpr = valResult->as.valDeclarationStatement->expression;
     ASSERT(callExpr->type == CALL_EXPRESSION);
-    ASSERT(strcmp(callExpr->as.callExpression->lambdaFunctionName->token.start, "applyOperation") == 0);
+    ASSERT(strcmp(callExpr->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "applyOperation") == 0);
     ASSERT(callExpr->as.callExpression->arguments->used == 2);
     ASSERT(callExpr->as.callExpression->arguments->values[1]->type == LAMBDA_EXPRESSION);
 
@@ -1645,12 +1645,12 @@ int test_parser_nested_calls() {
 
     Expression* callMultiplyByThree = valResult->as.valDeclarationStatement->expression;
     ASSERT(callMultiplyByThree->type == CALL_EXPRESSION);
-    ASSERT(strcmp(callMultiplyByThree->as.callExpression->lambdaFunctionName->token.start, "multiplyByThree") == 0);
+    ASSERT(strcmp(callMultiplyByThree->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "multiplyByThree") == 0);
     ASSERT(callMultiplyByThree->as.callExpression->arguments->used == 1);
 
     Expression* callAddTwo = callMultiplyByThree->as.callExpression->arguments->values[0];
     ASSERT(callAddTwo->type == CALL_EXPRESSION);
-    ASSERT(strcmp(callAddTwo->as.callExpression->lambdaFunctionName->token.start, "addTwo") == 0);
+    ASSERT(strcmp(callAddTwo->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "addTwo") == 0);
     ASSERT(callAddTwo->as.callExpression->arguments->used == 1);
     ASSERT(callAddTwo->as.callExpression->arguments->values[0]->type == PRIMARY_EXPRESSION);
     ASSERT(callAddTwo->as.callExpression->arguments->values[0]->as.primaryExpression->literal->type == NUMBER_LITERAL);
@@ -1725,7 +1725,7 @@ int test_parser_call_with_expression_args() {
 
     Expression* callExpr = valResult->as.valDeclarationStatement->expression;
     ASSERT(callExpr->type == CALL_EXPRESSION);
-    ASSERT(strcmp(callExpr->as.callExpression->lambdaFunctionName->token.start, "sum") == 0);
+    ASSERT(strcmp(callExpr->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "sum") == 0);
     ASSERT(callExpr->as.callExpression->arguments->used == 2);
 
     Expression* firstArg = callExpr->as.callExpression->arguments->values[0];
@@ -1806,7 +1806,7 @@ int test_parser_call_in_if_condition() {
 
     Expression* conditionExpr = ifStmt->as.selectionStatement->conditionExpression;
     ASSERT(conditionExpr->type == CALL_EXPRESSION);
-    ASSERT(strcmp(conditionExpr->as.callExpression->lambdaFunctionName->token.start, "isTen") == 0);
+    ASSERT(strcmp(conditionExpr->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "isTen") == 0);
     ASSERT(conditionExpr->as.callExpression->arguments->used == 1);
     ASSERT(conditionExpr->as.callExpression->arguments->values[0]->type == PRIMARY_EXPRESSION);
     ASSERT(strcmp(conditionExpr->as.callExpression->arguments->values[0]->as.primaryExpression->literal->as.identifierLiteral->token.start, "num") == 0);

--- a/test/unit/test.c
+++ b/test/unit/test.c
@@ -60,6 +60,7 @@ void all_unit_tests() {
     RUN_TEST(test_parser_nested_calls);
     RUN_TEST(test_parser_call_with_expression_args);
     RUN_TEST(test_parser_call_in_if_condition);
+    RUN_TEST(test_parser_chained_calls);
     RUN_TEST(test_parser_simple_return);
     RUN_TEST(test_parser_return_without_expression);
     RUN_TEST(test_parser_return_in_lambda);
@@ -97,6 +98,7 @@ void all_unit_tests() {
     RUN_TEST(test_compiler_lambda_expression_nested);
     RUN_TEST(test_compiler_call_expression_simple);
     RUN_TEST(test_compiler_call_expression_nested);
+    RUN_TEST(test_compiler_chained_calls);
     RUN_TEST(test_compiler_lambda_with_return);
     RUN_TEST(test_compiler_lambda_with_conditional_returns);
 


### PR DESCRIPTION
### Summary

This PR fixes chained function calls. This now works:
```
val makePrinter = lambda() { 
  lambda(strToPrint) { print strToPrint; }; 
};
makePrinter()("Success");
```

This PR also incidentally makes SolScript an LALR(1) grammar again, instead of LALR(2).


### Testing
Added parser, compiler, and end-to-end tests.