### PR TITLE
Full parser support for member expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,6 @@ expression:
   logical-or-expression
 
 
-
 struct-expression:
   "struct" "{" struct-declaration-list "}"
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -296,6 +296,13 @@ static void printExpression(const Expression* expression, int depth) {
             }
             break;
         }
+        case MEMBER_EXPRESSION: {
+            MemberExpression* memberExpr = expression->as.memberExpression;
+            printf("MemberExpression\n");
+            printExpression(memberExpr->leftHandSide, depth + 1);
+            printExpression(memberExpr->rightHandSide, depth + 1);
+            break;
+        }
     }
 }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -337,7 +337,7 @@ static Expression* postfixExpression(ASTParser* parser) {
             expr->as.callExpression = callExpr;
         } else if (match(parser, TOKEN_DOT)) {
             // Member access
-            Token* identifier = consume(parser, TOKEN_IDENTIFIER, "Expected an identifier after '.'.");
+            Token* identifier = consume(parser, TOKEN_IDENTIFIER, "Expected an identifier after '.' in member expression.");
 
             MemberExpression* memberExpr = allocateASTNode(MemberExpression);
             memberExpr->leftHandSide = expr;
@@ -351,6 +351,8 @@ static Expression* postfixExpression(ASTParser* parser) {
             identifierExpr->as.primaryExpression->literal = allocateASTNode(Literal);
             identifierExpr->as.primaryExpression->literal->type = IDENTIFIER_LITERAL;
             identifierExpr->as.primaryExpression->literal->as.identifierLiteral = identifierLiteral;
+
+            memberExpr->rightHandSide = identifierExpr;
 
             expr = allocateASTNode(Expression);
             expr->type = MEMBER_EXPRESSION;

--- a/test/unit/test.c
+++ b/test/unit/test.c
@@ -65,6 +65,10 @@ void all_unit_tests() {
     RUN_TEST(test_parser_return_without_expression);
     RUN_TEST(test_parser_return_in_lambda);
     RUN_TEST(test_parser_multiple_returns);
+    RUN_TEST(test_parser_member_expression_simple);
+    RUN_TEST(test_parser_member_and_call_expression);
+    RUN_TEST(test_parser_complex_member_and_call_expression);
+    RUN_TEST(test_parser_nested_call_expression);
 
     // Compiler tests
     RUN_TEST(test_compiler);


### PR DESCRIPTION
### Summary

Makes member expressions parsable and adds unit tests. I had already added most of the logic for parsing them in a different PR, so this one is pretty short.

### Testing

Added unit tests covering different cases. 

Existing tests pass; no manual testing is required anymore after https://github.com/CaioCamatta/sol-script/pull/19.