### PR TITLE
Make REPL debuggable in VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,15 @@
       "preLaunchTask": "Make debuggable program"
     },
     {
+      "name": "Build & Debug REPL",
+      "type": "lldb",
+      "request": "launch",
+      "program": "${workspaceFolder}/sol",
+      "cwd": "${workspaceFolder}",
+      "preLaunchTask": "Make debuggable program",
+      "console": "integratedTerminal"
+    },
+    {
       "name": "Build & Debug tests",
       "type": "lldb",
       "request": "launch",


### PR DESCRIPTION
### Summary
Make REPL debuggable in VSCode. Makes it easier to debug REPL-specific issues.

### Testing
Tested locally and it works. 