### PR TITLE
Add support for recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ To-do before v1.0 is released:
  - [x] Make debug logs optional for REPL or program execution
  - [X] Add Panic Mode error recovery to parser; stop crashing on every error.
  - [X] Implement objects / structs
- - [ ] Implement closures
+ - [ ] Support recursion
  - [ ] Audit all dynamic memory allocation and correctly free scanner, parser, and compiler objects.
  - [ ] Add garbage collector
 
@@ -363,11 +363,11 @@ These tasks are outside the scope of v1:
  - [ ] Improve compiler error logging; print line and column
  - [ ] Implement [NaN boxing](https://piotrduperas.com/posts/nan-boxing)
  - [ ] Add arrays
+ - [ ] Implement closures
 
-### Small Fixes To implement
-These are smaller-ish items to do at any time:
+### Small Fixes Needed
 
 - [X] Fix chained function calls
 - [ ] If-expressions at the end of function blocks should be used as function return.
-- [ ] Get recursive functions working
 - [ ] Returning null from functions doesnt work in structs
+- [ ] Explicitly fail when closing over variables

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ To-do before v1.0 is released:
  - [x] Make debug logs optional for REPL or program execution
  - [X] Add Panic Mode error recovery to parser; stop crashing on every error.
  - [X] Implement objects / structs
- - [ ] Support recursion
+ - [X] Support recursion
  - [ ] Audit all dynamic memory allocation and correctly free scanner, parser, and compiler objects.
  - [ ] Add garbage collector
 

--- a/code.sol
+++ b/code.sol
@@ -1,8 +1,8 @@
-val a = { 
-    val c = { 
-        val f = 1; 
-        f + 2; 
-    }; 
-    c + 3;
+val factorial = lambda (n) {
+    if (n <= 1) {
+        return 1;
+    } else {
+        return n * factorial(n - 1);
+    };
 };
-print a;
+print factorial(5);

--- a/code.sol
+++ b/code.sol
@@ -1,8 +1,10 @@
 val factorial = lambda (n) {
+    var result;
     if (n <= 1) {
-        return 1;
+        result = 1;
     } else {
-        return n * factorial(n - 1);
+        result = n * factorial(n - 1);
     };
+    return result;
 };
 print factorial(5);

--- a/code.sol
+++ b/code.sol
@@ -1,3 +1,7 @@
-var car = struct { year: 2020; };
-car.year;
-car.year;
+val a = { 
+    val c = { 
+        val f = 1; 
+        f + 2; 
+    }; 
+    c + 3;
+};

--- a/code.sol
+++ b/code.sol
@@ -5,6 +5,6 @@ val factorial = lambda (n) {
     } else {
         result = n * factorial(n - 1);
     };
-    return result;
+    result;
 };
-print factorial(5);
+print factorial(3);

--- a/code.sol
+++ b/code.sol
@@ -5,3 +5,4 @@ val a = {
     }; 
     c + 3;
 };
+print a;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -522,16 +522,16 @@ static void declareVariable(CompilerUnit* compiler, const char* name, size_t len
     char* identifierName = copyStringToHeap(name, length);
     if (compiler->isInGlobalScope) {
         if (isGlobalInTable(compiler, identifierName)) {
-            free(identifierName);
             errorAndExit(compiler, "%s \"%s\" is already declared. Redeclaration is not permitted.",
                          isModifiable ? "Var" : "Val", identifierName);
+            free(identifierName);
         }
         addGlobalToTable(compiler, identifierName, isModifiable);
     } else {
         if (findLocalByName(compiler, identifierName) != -1) {
-            free(identifierName);
             errorAndExit(compiler, "%s \"%s\" is already declared locally. Redeclaration is not permitted.",
                          isModifiable ? "Var" : "Val", identifierName);
+            free(identifierName);
         }
         placeLocalAtTopOfTempStack(compiler, identifierName, isModifiable);
     }

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -36,14 +36,20 @@ typedef struct {
 /**
  * During Compiler execution, we use this struct to predict what the VM stack will look like.
  *
- * This is necessary for various reasons. For example, local variables are references via
- * their position on the stack. So, to compile a variable access we need to predict what the VM
- * stack will look like during execution.
+ * Note: stack prediction is necessary for so the compiler can tell the VM what stack slots to access.
+ * For example, local variables are references via their position on the stack. So, to compile
+ * a variable access we need to predict what the VM stack will look like during execution.
  */
 typedef struct {
     u_int8_t currentStackHeight;  // The next empty spot on the stack
     Local tempStack[STACK_MAX];
 } PredictedStack;
+
+/**
+ * Represents a saved state of the predicted stack at a point in time.
+ * Used to restore stack state when exiting block scopes.
+ */
+typedef PredictedStack StackSnapshot;
 
 typedef struct CompilerUnit CompilerUnit;
 /**

--- a/test/end_to_end/scenarios.c
+++ b/test/end_to_end/scenarios.c
@@ -863,3 +863,71 @@ static int test_struct_chained_access() {
         "print complex.a().b.c();");
     EXPECT("42.000000");
 }
+
+// Test blocks with multiple levels of nesting and shadowing
+static int test_blocks_deep_nesting() {
+    SCENARIO(
+        "var x = 1;"
+        "{"
+        "    var x = 2;"
+        "    print x;"
+        "    {"
+        "        var x = 3;"
+        "        print x;"
+        "        {"
+        "            var x = 4;"
+        "            print x;"
+        "        }"
+        "        print x;"
+        "    }"
+        "    print x;"
+        "}"
+        "print x;");
+    EXPECT("2.000000\n3.000000\n4.000000\n3.000000\n2.000000\n1.000000");
+}
+
+// Test complex nested block expressions with return values
+// static int test_blocks_nested_expressions() {
+//     SCENARIO(
+//         "val result = {"
+//         "    val a = {"
+//         "        val x = 5;"
+//         "        x * 2;"
+//         "    };"
+//         "    val b = {"
+//         "        val y = {"
+//         "            val z = 3;"
+//         "            z + 1;"
+//         "        };"
+//         "        y * 2;"
+//         "    };"
+//         "    a + b;"
+//         "};"
+//         "print result;");
+//     EXPECT("18.000000");
+// }
+
+// Test struct creation and manipulation in complex scenarios
+static int test_structs_complex() {
+    SCENARIO(
+        "var makePoint = lambda(x, y) {"
+        "    struct {"
+        "        x: x;"
+        "        y: y;"
+        "        length: lambda() {"
+        "            val l = this.x * this.x + this.y * this.y;"
+        "            return l;"
+        "        };"
+        "        scale: lambda(factor) {"
+        "            this.x = this.x * factor;"
+        "            this.y = this.y * factor;"
+        "            return this;"
+        "        };"
+        "    };"
+        "};"
+        "val point = makePoint(3, 4);"
+        "print point.length();"    // 3^2 + 4^2 = 25
+        "point.scale(2);"          // x=6, y=8
+        "print point.length();");  // 6^2 + 8^2 = 100
+    EXPECT("25.000000\n100.000000");
+}

--- a/test/end_to_end/scenarios.c
+++ b/test/end_to_end/scenarios.c
@@ -715,6 +715,11 @@ static int test_scope_global_vs_local() {
     EXPECT("7.000000");
 }
 
+static int test_scope_nested_declarations() {
+    SCENARIO("val a = { val c = { val f = 1; f + 2; }; c + 3; }; print a;")
+    EXPECT("6.000000");
+}
+
 static int test_var_declaration_multiple_declarations() {
     SCENARIO(
         "var a = 1;"

--- a/test/end_to_end/scenarios.c
+++ b/test/end_to_end/scenarios.c
@@ -275,18 +275,18 @@ static int test_functions_single_parameter() {
     EXPECT("5.000000\nhello");
 }
 
-// static int test_functions_recursive() {
-//     SCENARIO(
-//         "val factorial = lambda (n) {"
-//         "    if (n <= 1) {"
-//         "        1;"
-//         "    } else {"
-//         "        n * factorial(n - 1);"
-//         "    };"
-//         "};"
-//         "print factorial(5);");
-//     EXPECT("120.000000");
-// }
+static int test_functions_recursive() {
+    SCENARIO(
+        "val factorial = lambda (n) {"
+        "    if (n <= 1) {"
+        "        return 1;"
+        "    } else {"
+        "        return n * factorial(n - 1);"
+        "    };"
+        "};"
+        "print factorial(5);");
+    EXPECT("120.000000");
+}
 
 static int test_functions_modify_global() {
     SCENARIO(

--- a/test/end_to_end/scenarios.c
+++ b/test/end_to_end/scenarios.c
@@ -864,70 +864,23 @@ static int test_struct_chained_access() {
     EXPECT("42.000000");
 }
 
-// Test blocks with multiple levels of nesting and shadowing
-static int test_blocks_deep_nesting() {
-    SCENARIO(
-        "var x = 1;"
-        "{"
-        "    var x = 2;"
-        "    print x;"
-        "    {"
-        "        var x = 3;"
-        "        print x;"
-        "        {"
-        "            var x = 4;"
-        "            print x;"
-        "        }"
-        "        print x;"
-        "    }"
-        "    print x;"
-        "}"
-        "print x;");
-    EXPECT("2.000000\n3.000000\n4.000000\n3.000000\n2.000000\n1.000000");
-}
-
 // Test complex nested block expressions with return values
-// static int test_blocks_nested_expressions() {
-//     SCENARIO(
-//         "val result = {"
-//         "    val a = {"
-//         "        val x = 5;"
-//         "        x * 2;"
-//         "    };"
-//         "    val b = {"
-//         "        val y = {"
-//         "            val z = 3;"
-//         "            z + 1;"
-//         "        };"
-//         "        y * 2;"
-//         "    };"
-//         "    a + b;"
-//         "};"
-//         "print result;");
-//     EXPECT("18.000000");
-// }
-
-// Test struct creation and manipulation in complex scenarios
-static int test_structs_complex() {
+static int test_blocks_nested_expressions() {
     SCENARIO(
-        "var makePoint = lambda(x, y) {"
-        "    struct {"
-        "        x: x;"
-        "        y: y;"
-        "        length: lambda() {"
-        "            val l = this.x * this.x + this.y * this.y;"
-        "            return l;"
-        "        };"
-        "        scale: lambda(factor) {"
-        "            this.x = this.x * factor;"
-        "            this.y = this.y * factor;"
-        "            return this;"
-        "        };"
+        "val result = {"
+        "    val a = {"
+        "        val x = 5;"
+        "        x * 2;"
         "    };"
+        "    val b = {"
+        "        val y = {"
+        "            val z = 3;"
+        "            z + 1;"
+        "        };"
+        "        y * 2;"
+        "    };"
+        "    a + b;"
         "};"
-        "val point = makePoint(3, 4);"
-        "print point.length();"    // 3^2 + 4^2 = 25
-        "point.scale(2);"          // x=6, y=8
-        "print point.length();");  // 6^2 + 8^2 = 100
-    EXPECT("25.000000\n100.000000");
+        "print result;");
+    EXPECT("18.000000");
 }

--- a/test/end_to_end/scenarios.c
+++ b/test/end_to_end/scenarios.c
@@ -288,6 +288,21 @@ static int test_functions_recursive() {
     EXPECT("120.000000");
 }
 
+static int test_functions_recursive_implicit_return() {
+    SCENARIO(
+        "val factorial = lambda (n) {"
+        "    var result;"
+        "    if (n <= 1) {"
+        "        result = 1;"
+        "    } else {"
+        "        result = n * factorial(n - 1);"
+        "    };"
+        "    result;"
+        "};"
+        "print factorial(5);");
+    EXPECT("120.000000");
+}
+
 static int test_functions_modify_global() {
     SCENARIO(
         "var x = 10;"

--- a/test/end_to_end/test.c
+++ b/test/end_to_end/test.c
@@ -41,7 +41,7 @@ void all_end_to_end_tests() {
     RUN_TEST(test_functions_return_in_nested_lambda);
     RUN_TEST(test_functions_nested_calls);
     // RUN_TEST(test_functions_if_statement_in_lambda); -- Needs to be fixed
-    // RUN_TEST(test_functions_recursive); -- Needs to be fixed
+    RUN_TEST(test_functions_recursive);
     RUN_TEST(test_functions_chained_calls);
 
     /* If statements */

--- a/test/end_to_end/test.c
+++ b/test/end_to_end/test.c
@@ -18,8 +18,7 @@ void all_end_to_end_tests() {
     RUN_TEST(test_block_expressions_simple_example);
     RUN_TEST(test_block_expressions_only_expression);
     RUN_TEST(test_block_expressions_block_in_if_condition);
-    RUN_TEST(test_blocks_deep_nesting);
-    // RUN_TEST(test_blocks_nested_expressions); -- needs to be fixed
+    RUN_TEST(test_blocks_nested_expressions);
 
     /* Call expressions */
     RUN_TEST(test_call_expressions_call_in_binary_expression);

--- a/test/end_to_end/test.c
+++ b/test/end_to_end/test.c
@@ -42,6 +42,7 @@ void all_end_to_end_tests() {
     RUN_TEST(test_functions_nested_calls);
     // RUN_TEST(test_functions_if_statement_in_lambda); -- Needs to be fixed
     RUN_TEST(test_functions_recursive);
+    RUN_TEST(test_functions_recursive_implicit_return);
     RUN_TEST(test_functions_chained_calls);
 
     /* If statements */

--- a/test/end_to_end/test.c
+++ b/test/end_to_end/test.c
@@ -18,6 +18,8 @@ void all_end_to_end_tests() {
     RUN_TEST(test_block_expressions_simple_example);
     RUN_TEST(test_block_expressions_only_expression);
     RUN_TEST(test_block_expressions_block_in_if_condition);
+    RUN_TEST(test_blocks_deep_nesting);
+    // RUN_TEST(test_blocks_nested_expressions); -- needs to be fixed
 
     /* Call expressions */
     RUN_TEST(test_call_expressions_call_in_binary_expression);

--- a/test/end_to_end/test.c
+++ b/test/end_to_end/test.c
@@ -64,6 +64,7 @@ void all_end_to_end_tests() {
     RUN_TEST(test_scope_consecutive_blocks);
     RUN_TEST(test_scope_nested_blocks);
     RUN_TEST(test_scope_global_vs_local);
+    RUN_TEST(test_scope_nested_declarations);
 
     /* Variable declaration */
     RUN_TEST(test_var_declaration_multiple_declarations);

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -1390,8 +1390,8 @@ int test_compiler_lambda_expression_simple() {
     // Verify the function's bytecode
     Function* function = compiledCode.topLevelCodeObject.constantPool.values[0].as.lambda;
     ASSERT(function->parameterCount == 2);
-    ASSERT(function->code->bytecodeArray.values[0].type == OP_GET_LOCAL_VAR_FAST);
-    ASSERT(function->code->bytecodeArray.values[1].type == OP_GET_LOCAL_VAR_FAST);
+    ASSERT(function->code->bytecodeArray.values[0].type == OP_GET_LOCAL_VAL_FAST);
+    ASSERT(function->code->bytecodeArray.values[1].type == OP_GET_LOCAL_VAL_FAST);
     ASSERT(function->code->bytecodeArray.values[2].type == OP_BINARY_ADD);
     ASSERT(function->code->bytecodeArray.values[3].type == OP_POPN);
     ASSERT(function->code->bytecodeArray.values[4].type == OP_RETURN);
@@ -1439,7 +1439,7 @@ int test_compiler_lambda_expression_nested() {
     // Verify the inner function's bytecode
     Function* innerFunction = outerFunction->code->constantPool.values[0].as.lambda;
     ASSERT(innerFunction->parameterCount == 1);
-    ASSERT(innerFunction->code->bytecodeArray.values[0].type == OP_GET_LOCAL_VAR_FAST);  // y
+    ASSERT(innerFunction->code->bytecodeArray.values[0].type == OP_GET_LOCAL_VAL_FAST);  // y
     ASSERT(innerFunction->code->bytecodeArray.values[1].type == OP_LOAD_CONSTANT);       // 1
     ASSERT(innerFunction->code->bytecodeArray.values[2].type == OP_BINARY_ADD);
     ASSERT(innerFunction->code->bytecodeArray.values[3].type == OP_POPN);
@@ -1685,7 +1685,7 @@ int test_compiler_lambda_with_conditional_returns() {
     ASSERT(lambda->parameterCount == 1);
 
     Bytecode expectedLambdaBytecode[] = {
-        {.type = OP_GET_LOCAL_VAR_FAST},
+        {.type = OP_GET_LOCAL_VAL_FAST},
         {.type = OP_LOAD_CONSTANT},
         {.type = OP_BINARY_GT},
         {.type = OP_JUMP_IF_FALSE},

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -1640,13 +1640,11 @@ int test_compiler_lambda_with_return() {
     Bytecode expectedLambdaBytecode[] = {
         {.type = OP_LOAD_CONSTANT},
         {.type = OP_RETURN},
-        {.type = OP_NULL},
-        {.type = OP_SWAP},
         {.type = OP_POPN},
         {.type = OP_POPN},
         {.type = OP_RETURN},
     };
-    BytecodeArray expectedLambdaBytecodeArray = {.values = expectedLambdaBytecode, .used = 7};
+    BytecodeArray expectedLambdaBytecodeArray = {.values = expectedLambdaBytecode, .used = 5};
 
     ASSERT(compareTypesInBytecodeArrays(expectedLambdaBytecodeArray, lambda->code->bytecodeArray));
     ASSERT(lambda->code->constantPool.values[0].as.number == 10);

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -1393,8 +1393,7 @@ int test_compiler_lambda_expression_simple() {
     ASSERT(function->code->bytecodeArray.values[0].type == OP_GET_LOCAL_VAL_FAST);
     ASSERT(function->code->bytecodeArray.values[1].type == OP_GET_LOCAL_VAL_FAST);
     ASSERT(function->code->bytecodeArray.values[2].type == OP_BINARY_ADD);
-    ASSERT(function->code->bytecodeArray.values[3].type == OP_POPN);
-    ASSERT(function->code->bytecodeArray.values[4].type == OP_RETURN);
+    ASSERT(function->code->bytecodeArray.values[3].type == OP_RETURN);
 
     FREE_COMPILER
 
@@ -1433,8 +1432,7 @@ int test_compiler_lambda_expression_nested() {
     Function* outerFunction = compiledCode.topLevelCodeObject.constantPool.values[0].as.lambda;
     ASSERT(outerFunction->parameterCount == 1);
     ASSERT(outerFunction->code->bytecodeArray.values[0].type == OP_LAMBDA);
-    ASSERT(outerFunction->code->bytecodeArray.values[1].type == OP_POPN);
-    ASSERT(outerFunction->code->bytecodeArray.values[2].type == OP_RETURN);
+    ASSERT(outerFunction->code->bytecodeArray.values[1].type == OP_RETURN);
 
     // Verify the inner function's bytecode
     Function* innerFunction = outerFunction->code->constantPool.values[0].as.lambda;
@@ -1442,8 +1440,7 @@ int test_compiler_lambda_expression_nested() {
     ASSERT(innerFunction->code->bytecodeArray.values[0].type == OP_GET_LOCAL_VAL_FAST);  // y
     ASSERT(innerFunction->code->bytecodeArray.values[1].type == OP_LOAD_CONSTANT);       // 1
     ASSERT(innerFunction->code->bytecodeArray.values[2].type == OP_BINARY_ADD);
-    ASSERT(innerFunction->code->bytecodeArray.values[3].type == OP_POPN);
-    ASSERT(innerFunction->code->bytecodeArray.values[4].type == OP_RETURN);
+    ASSERT(innerFunction->code->bytecodeArray.values[3].type == OP_RETURN);
 
     FREE_COMPILER
 
@@ -1641,10 +1638,9 @@ int test_compiler_lambda_with_return() {
         {.type = OP_LOAD_CONSTANT},
         {.type = OP_RETURN},
         {.type = OP_POPN},
-        {.type = OP_POPN},
         {.type = OP_RETURN},
     };
-    BytecodeArray expectedLambdaBytecodeArray = {.values = expectedLambdaBytecode, .used = 5};
+    BytecodeArray expectedLambdaBytecodeArray = {.values = expectedLambdaBytecode, .used = 4};
 
     ASSERT(compareTypesInBytecodeArrays(expectedLambdaBytecodeArray, lambda->code->bytecodeArray));
     ASSERT(lambda->code->constantPool.values[0].as.number == 10);
@@ -1697,10 +1693,9 @@ int test_compiler_lambda_with_conditional_returns() {
         {.type = OP_POPN},
         {.type = OP_NULL},
         {.type = OP_POPN},
-        {.type = OP_POPN},
         {.type = OP_RETURN},
     };
-    BytecodeArray expectedLambdaBytecodeArray = {.values = expectedLambdaBytecode, .used = 16};
+    BytecodeArray expectedLambdaBytecodeArray = {.values = expectedLambdaBytecode, .used = 15};
 
     ASSERT(compareTypesInBytecodeArrays(expectedLambdaBytecodeArray, lambda->code->bytecodeArray));
     ASSERT(lambda->code->constantPool.values[0].as.number == 0);


### PR DESCRIPTION
### Summary
This PR adds support for recursion. 

The main change that made this possible was separating variable _declaration_ and _initialization_. Before a variable is initialized (i.e. before its value is compiled), the compiler will declare its name and make it available in the current scope. Once declared, the name can be referenced during compilation of the variable's right-hand-side. This enables recursive functions to be compiled, such as:
 
```
val factorial = lambda (n) {
    if (n <= 1) {
        return 1;
    } else {
        return n * factorial(n - 1);
    };
};
print factorial(3);
```

A lot of changes to block compilation were also necessary. SolScript local variables live in the VM stack and the Compiler predicts what position of the stack these variables will use - this turned out to be tricky for recursive functions. To solve that, this PR introduces `StackSnapshot` to block compilation. When compiling a block, we 
* take a snapshot (copy) of the current predicted stack state
* create a temporary predicted stack
* compile the block using that new stack
* once compilation is done, we throw away the new stack and restore the snapshot

See comments in `visitBlockExpression` for a more thorough explanation.

Other changes:
* Refactored `val` and `var` to decrease code repetition
* Fixed fix `isModifiable` being incorrectly named in the compiler and used to represent if something is *constant*.

### Tests
Existing tests all pass after the `PredictedStack` refactor.

Add end-to-end tests for recursion.