### PR TITLE
Fix some memory leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ Features
 Small items and fixes:
 
 - [x] Fix chained function calls
-- [ ] Audit all dynamic memory allocation
+- [x] Audit all dynamic memory allocation and fix leaks
 - [ ] If-expressions at the end of function blocks should be used as function return.
 - [ ] Returning null from functions doesnt work in structs
 - [ ] Explicitly fail when closing over variables

--- a/src/bytecode.h
+++ b/src/bytecode.h
@@ -167,4 +167,6 @@ typedef struct {
     // Other metadata can go in here
 } CompiledCode;
 
+void freeCompiledCode(CompiledCode* code);
+
 #endif

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -78,8 +78,8 @@ typedef struct {
 /* Initialize a Compiler with an AST to be parsed */
 void initCompilerState(CompilerState* compilerState, Source* ASTSource);
 
-/* Free a Compiler state and all of its fields, excluding the ASTSource*/
-void freeCompilerState(CompilerState* compilerState);
+/* Free a Compiler state and all of its fields, except the ASTSource and the compiled code */
+void freeCompilerStateButNotCompiledCode(CompilerState* compilerState);
 
 /**
  * Compile an AST into bytecode.

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -78,7 +78,7 @@ typedef struct {
 /* Initialize a Compiler with an AST to be parsed */
 void initCompilerState(CompilerState* compilerState, Source* ASTSource);
 
-/* Free a Compiler state and all of its fields, including the ASTSource*/
+/* Free a Compiler state and all of its fields, excluding the ASTSource*/
 void freeCompilerState(CompilerState* compilerState);
 
 /**

--- a/src/main.c
+++ b/src/main.c
@@ -59,13 +59,14 @@ static void repl() {
         printf("\n");
 
         FREE_ARRAY(tokens);
-        freeParser(&treeParser);
+        freeParserButNotAST(&treeParser);
     }
 
     // Clean up
     FREE_ARRAY(sharedConstantPool);
     freeVM(&vm);
-    freeCompilerState(&compiler);
+    freeCompilerStateButNotCompiledCode(&compiler);
+    freeCompiledCode(&initialCompiledCode);
 }
 
 static void executeFile(const char* path) {
@@ -86,6 +87,12 @@ static void executeFile(const char* path) {
     CompilerState compiler;
     initCompilerState(&compiler, source);
     CompiledCode compiledCode = compile(&compiler);
+
+    // Free everything except the compiled code
+    free(sourceCode);
+    FREE_ARRAY(tokens);
+    freeParserButNotAST(&treeParser);                // Parser can be freed now
+    freeCompilerStateButNotCompiledCode(&compiler);  // Compiler can be freed now (compiled code will remain)
 
     // Then, execute the compiledCode.
     VM vm;

--- a/src/main.c
+++ b/src/main.c
@@ -60,6 +60,7 @@ static void repl() {
 
         FREE_ARRAY(tokens);
         freeParserButNotAST(&treeParser);
+        freeSource(source);
     }
 
     // Clean up
@@ -92,6 +93,7 @@ static void executeFile(const char* path) {
     free(sourceCode);
     FREE_ARRAY(tokens);
     freeParserButNotAST(&treeParser);                // Parser can be freed now
+    freeSource(source);                              // Source can be freed now
     freeCompilerStateButNotCompiledCode(&compiler);  // Compiler can be freed now (compiled code will remain)
 
     // Then, execute the compiledCode.

--- a/src/main.c
+++ b/src/main.c
@@ -59,7 +59,7 @@ static void repl() {
         printf("\n");
 
         FREE_ARRAY(tokens);
-        freeSource(source);
+        freeParser(&treeParser);
     }
 
     // Clean up

--- a/src/main.c
+++ b/src/main.c
@@ -64,7 +64,7 @@ static void repl() {
 
     // Clean up
     FREE_ARRAY(sharedConstantPool);
-    freeVM(&vm);
+    freeVMButNotCompiledCode(&vm);
     freeCompilerStateButNotCompiledCode(&compiler);
     freeCompiledCode(&initialCompiledCode);
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -202,11 +202,6 @@ void freeSource(Source* source) {
 void freeParserButNotAST(ASTParser* parser) {
     FREE_ARRAY(parser->errors);
 
-    if (parser->source) {
-        freeSource(parser->source);
-        parser->source = NULL;
-    }
-
     parser->current = NULL;
     parser->previous = NULL;
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -198,9 +198,17 @@ void freeSource(Source* source) {
     free(source);
 }
 
+// Free parser and AST, but not the Token array or the original code string.
 void freeParser(ASTParser* parser) {
-    // TODO: complete this function
     FREE_ARRAY(parser->errors);
+
+    if (parser->source) {
+        freeSource(parser->source);
+        parser->source = NULL;
+    }
+
+    parser->current = NULL;
+    parser->previous = NULL;
 }
 
 // Peek token to be immediately parsed.
@@ -1181,8 +1189,6 @@ Source* parseAST(ASTParser* parser) {
     printf("AST\n");
     printAST(parser->source);
 #endif
-
-    freeParser(parser);
 
     return parser->source;
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -199,7 +199,7 @@ void freeSource(Source* source) {
 }
 
 // Free parser and AST, but not the Token array or the original code string.
-void freeParser(ASTParser* parser) {
+void freeParserButNotAST(ASTParser* parser) {
     FREE_ARRAY(parser->errors);
 
     if (parser->source) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -29,12 +29,172 @@ void initASTParser(ASTParser* parser, const TokenArray tokens) {
 // Allocate an AST node (literal, expression, statement) on the heap and return a pointer to the allocated node.
 #define allocateASTNode(type) (type*)malloc(sizeof(type));
 
-// Free an AST node (literal, expression, statement) on the heap.
-#define freeASTNode(node) free(node);
+void freeStatement(Statement* stmt);  // Forward declaration
 
-// Free memory allocated for the Source of an AST.
+void freeLiteral(Literal* literal) {
+    if (!literal) return;
+    switch (literal->type) {
+        case BOOLEAN_LITERAL:
+            free(literal->as.booleanLiteral);
+            break;
+        case NUMBER_LITERAL:
+            free(literal->as.numberLiteral);
+            break;
+        case IDENTIFIER_LITERAL:
+            free(literal->as.identifierLiteral);
+            break;
+        case STRING_LITERAL:
+            free(literal->as.stringLiteral);
+            break;
+    }
+    free(literal);
+}
+
+void freeExpression(Expression* expr) {
+    if (!expr) return;
+
+    switch (expr->type) {
+        case LOGICAL_OR_EXPRESSION:
+            freeExpression(expr->as.logicalOrExpression->leftExpression);
+            freeExpression(expr->as.logicalOrExpression->rightExpression);
+            free(expr->as.logicalOrExpression);
+            break;
+        case LOGICAL_AND_EXPRESSION:
+            freeExpression(expr->as.logicalAndExpression->leftExpression);
+            freeExpression(expr->as.logicalAndExpression->rightExpression);
+            free(expr->as.logicalAndExpression);
+            break;
+        case EQUALITY_EXPRESSION:
+            freeExpression(expr->as.equalityExpression->leftExpression);
+            freeExpression(expr->as.equalityExpression->rightExpression);
+            free(expr->as.equalityExpression);
+            break;
+        case COMPARISON_EXPRESSION:
+            freeExpression(expr->as.comparisonExpression->leftExpression);
+            freeExpression(expr->as.comparisonExpression->rightExpression);
+            free(expr->as.comparisonExpression);
+            break;
+        case ADDITIVE_EXPRESSION:
+            freeExpression(expr->as.additiveExpression->leftExpression);
+            freeExpression(expr->as.additiveExpression->rightExpression);
+            free(expr->as.additiveExpression);
+            break;
+        case MULTIPLICATIVE_EXPRESSION:
+            freeExpression(expr->as.multiplicativeExpression->leftExpression);
+            freeExpression(expr->as.multiplicativeExpression->rightExpression);
+            free(expr->as.multiplicativeExpression);
+            break;
+        case BLOCK_EXPRESSION:
+            for (size_t i = 0; i < expr->as.blockExpression->statementArray.used; i++) {
+                freeStatement(expr->as.blockExpression->statementArray.values[i]);
+            }
+            FREE_ARRAY(expr->as.blockExpression->statementArray);
+            freeExpression(expr->as.blockExpression->lastExpression);
+            free(expr->as.blockExpression);
+            break;
+        case UNARY_EXPRESSION:
+            freeExpression(expr->as.unaryExpression->rightExpression);
+            free(expr->as.unaryExpression);
+            break;
+        case PRIMARY_EXPRESSION:
+            freeLiteral(expr->as.primaryExpression->literal);
+            free(expr->as.primaryExpression);
+            break;
+        case LAMBDA_EXPRESSION:
+            FREE_ARRAY((*(expr->as.lambdaExpression->parameters)));
+            free(expr->as.lambdaExpression->parameters);
+            freeExpression((Expression*)expr->as.lambdaExpression->bodyBlock);
+            free(expr->as.lambdaExpression);
+            break;
+        case CALL_EXPRESSION:
+            freeExpression(expr->as.callExpression->leftHandSide);
+            for (size_t i = 0; i < expr->as.callExpression->arguments->used; i++) {
+                freeExpression(expr->as.callExpression->arguments->values[i]);
+            }
+            FREE_ARRAY((*(expr->as.callExpression->arguments)));
+            free(expr->as.callExpression->arguments);
+            free(expr->as.callExpression);
+            break;
+        case MEMBER_EXPRESSION:
+            freeExpression(expr->as.memberExpression->leftHandSide);
+            freeExpression(expr->as.memberExpression->rightHandSide);
+            free(expr->as.memberExpression);
+            break;
+        case STRUCT_EXPRESSION:
+            for (size_t i = 0; i < expr->as.structExpression->declarationArray.used; i++) {
+                StructDeclaration* decl = expr->as.structExpression->declarationArray.values[i];
+                freeLiteral((Literal*)decl->identifier);
+                freeExpression(decl->maybeExpression);
+                free(decl);
+            }
+            FREE_ARRAY(expr->as.structExpression->declarationArray);
+            free(expr->as.structExpression);
+            break;
+    }
+    free(expr);
+}
+
+void freeStatement(Statement* stmt) {
+    if (!stmt) return;
+
+    switch (stmt->type) {
+        case EXPRESSION_STATEMENT:
+            freeExpression(stmt->as.expressionStatement->expression);
+            free(stmt->as.expressionStatement);
+            break;
+        case VAL_DECLARATION_STATEMENT:
+            freeLiteral((Literal*)stmt->as.valDeclarationStatement->identifier);
+            freeExpression(stmt->as.valDeclarationStatement->expression);
+            free(stmt->as.valDeclarationStatement);
+            break;
+        case VAR_DECLARATION_STATEMENT:
+            freeLiteral((Literal*)stmt->as.varDeclarationStatement->identifier);
+            freeExpression(stmt->as.varDeclarationStatement->maybeExpression);
+            free(stmt->as.varDeclarationStatement);
+            break;
+        case PRINT_STATEMENT:
+            freeExpression(stmt->as.printStatement->expression);
+            free(stmt->as.printStatement);
+            break;
+        case BLOCK_STATEMENT:
+            for (size_t i = 0; i < stmt->as.blockStatement->statementArray.used; i++) {
+                freeStatement(stmt->as.blockStatement->statementArray.values[i]);
+            }
+            FREE_ARRAY(stmt->as.blockStatement->statementArray);
+            free(stmt->as.blockStatement);
+            break;
+        case SELECTION_STATEMENT:
+            freeExpression(stmt->as.selectionStatement->conditionExpression);
+            freeStatement(stmt->as.selectionStatement->trueStatement);
+            if (stmt->as.selectionStatement->falseStatement) {
+                freeStatement(stmt->as.selectionStatement->falseStatement);
+            }
+            free(stmt->as.selectionStatement);
+            break;
+        case ASSIGNMENT_STATEMENT:
+            freeExpression(stmt->as.assignmentStatement->target);
+            freeExpression(stmt->as.assignmentStatement->value);
+            free(stmt->as.assignmentStatement);
+            break;
+        case ITERATION_STATEMENT:
+            freeExpression(stmt->as.iterationStatement->conditionExpression);
+            freeStatement(stmt->as.iterationStatement->bodyStatement);
+            free(stmt->as.iterationStatement);
+            break;
+        case RETURN_STATEMENT:
+            freeExpression(stmt->as.returnStatement->expression);
+            free(stmt->as.returnStatement);
+            break;
+    }
+    free(stmt);
+}
+
+// Free the memory allocated for the Source of an AST.
 void freeSource(Source* source) {
-    // TODO: add logic to make freeing recursive
+    if (!source) return;
+    for (int i = 0; i < source->numberOfStatements; i++) {
+        freeStatement(source->rootStatements[i]);
+    }
     free(source);
 }
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -55,8 +55,8 @@ Source* parseASTFromTokens(ASTParser* treeParser, TokenArray* tokenArray);
 void freeSource(Source* source);
 
 /**
- * Free memory allocated to the AST parser, but NOT its compiled AST.
- * Use freeSource to free the AST.
+ * Free memory allocated to the AST parser AND its compiled AST.
+ * Does NOT free the the Token array or the original code string.
  */
 void freeParser(ASTParser* parser);
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -58,7 +58,7 @@ void freeSource(Source* source);
  * Free memory allocated to the AST parser AND its compiled AST.
  * Does NOT free the the Token array or the original code string.
  */
-void freeParser(ASTParser* parser);
+void freeParserButNotAST(ASTParser* parser);
 
 /**
  *  Initialize treeParser at the beginning of the given token array to be parsed.

--- a/src/vm.c
+++ b/src/vm.c
@@ -32,9 +32,10 @@ void initVM(VM* vm, CompiledCode compiledCode) {
     vm->currFrame = frame;
 }
 
-void freeVM(VM* vm) {
+void freeVMButNotCompiledCode(VM* vm) {
     // Free the top level object we manually initialized in initVM;
     free(vm->frames[0].codeObject);
+    freeHashTable(&vm->globals);
 }
 
 /* Print a runtime error and exit. */

--- a/src/vm.h
+++ b/src/vm.h
@@ -59,6 +59,6 @@ void step(VM* vm);
 void initVM(VM* vm, CompiledCode compiledCode);
 
 /* Free a VM and its structs. */
-void freeVM(VM* vm);
+void freeVMButNotCompiledCode(VM* vm);
 
 #endif

--- a/test/end_to_end/utils.h
+++ b/test/end_to_end/utils.h
@@ -30,7 +30,7 @@ void execute_solscript(const char* sourceCode) {
     run(&vm);
 
     // Clean up
-    freeCompilerState(&compiler);
-    freeParser(&parser);
+    freeCompilerStateButNotCompiledCode(&compiler);
+    freeParserButNotAST(&parser);
     FREE_ARRAY(tokens);
 }

--- a/test/end_to_end/utils.h
+++ b/test/end_to_end/utils.h
@@ -32,5 +32,6 @@ void execute_solscript(const char* sourceCode) {
     // Clean up
     freeCompilerStateButNotCompiledCode(&compiler);
     freeParserButNotAST(&parser);
+    freeSource(source);
     FREE_ARRAY(tokens);
 }

--- a/test/end_to_end/utils.h
+++ b/test/end_to_end/utils.h
@@ -31,7 +31,6 @@ void execute_solscript(const char* sourceCode) {
 
     // Clean up
     freeCompilerState(&compiler);
-    freeSource(source);
     freeParser(&parser);
     FREE_ARRAY(tokens);
 }

--- a/test/unit/src/compiler_test.c
+++ b/test/unit/src/compiler_test.c
@@ -360,7 +360,7 @@ static int compareTypesInBytecodeArrays(BytecodeArray expected, BytecodeArray ac
     printCompiledCode(compiledCode);
 
 // Macro to free the compiler state (assumed to exist in lexical scope)
-#define FREE_COMPILER freeCompilerState(&compilerState);
+#define FREE_COMPILER freeCompilerStateButNotCompiledCode(&compilerState);
 
 // -------------------------------------------------------------------------
 // --------------------------------- Tests ---------------------------------

--- a/test/unit/src/parser_test.c
+++ b/test/unit/src/parser_test.c
@@ -94,7 +94,6 @@ int test_parser_simple_expression() {
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "2") == 0);
 
     // Clean up
-    freeSource(source);
     freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -110,7 +109,7 @@ int test_parser_print_statement() {
     ASSERT(source->rootStatements[0]->as.printStatement->expression->type == ADDITIVE_EXPRESSION);
 
     FREE_ARRAY(tokens);
-    freeSource(source);
+
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -153,7 +152,6 @@ int test_parser_logical_or_expression() {
     ASSERT(rightPrimary->literal->type == BOOLEAN_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.booleanLiteral->token.start, "false") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -194,7 +192,6 @@ int test_parser_logical_and_expression() {
     ASSERT(rightPrimary->literal->type == BOOLEAN_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.booleanLiteral->token.start, "true") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -235,7 +232,6 @@ int test_parser_equality_expression() {
     ASSERT(rightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "5") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -275,7 +271,6 @@ int test_parser_comparison_expression() {
     ASSERT(rightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "5") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -315,7 +310,6 @@ int test_parser_multiplicative_expression() {
     ASSERT(rightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "2") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -349,7 +343,6 @@ int test_parser_unary_expression() {
     ASSERT(rightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "1") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -379,7 +372,6 @@ int test_parser_boolean_literal() {
     ASSERT(primaryExpr->literal->type == BOOLEAN_LITERAL);
     ASSERT(strcmp(primaryExpr->literal->as.booleanLiteral->token.start, "true") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -479,7 +471,6 @@ int test_parser_complex_expression() {
     ASSERT(subRightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(subRightPrimary->literal->as.numberLiteral->token.start, "2") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -525,7 +516,7 @@ int test_parser_nested_parentheses_expression() {
     ASSERT(rightExpression->type == MULTIPLICATIVE_EXPRESSION);  // The nested expression should be multiplication
 
     // Cleanup
-    freeSource(source);
+
     freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -574,7 +565,7 @@ int test_parser_variable_declaration_and_reading() {
     ASSERT(strncmp(printIdLiteral->token.start, "x", printIdLiteral->token.length) == 0);
 
     // Cleanup
-    freeSource(source);
+
     freeParser(&parser);
     FREE_ARRAY(tokens);
 
@@ -608,7 +599,7 @@ int test_parser_string_literal() {
     ASSERT(strcmp(primaryExpression->literal->as.stringLiteral->token.start, "\"Hello, World!\"") == 0);
 
     // Cleanup
-    freeSource(source);
+
     freeParser(&parser);
     FREE_ARRAY(tokens);
 
@@ -650,7 +641,7 @@ int test_parser_block_statement() {
     ASSERT(printStmt->expression->type == PRIMARY_EXPRESSION);
 
     // Cleanup
-    freeSource(source);
+
     freeParser(&parser);
     FREE_ARRAY(tokens);
     return SUCCESS_RETURN_CODE;
@@ -679,7 +670,6 @@ int test_parser_if_statement_true_branch_only() {
     ASSERT(printStmt->expression->as.primaryExpression->literal->type == STRING_LITERAL);
     ASSERT(strcmp(printStmt->expression->as.primaryExpression->literal->as.stringLiteral->token.start, "\"Hello, World!\"") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     FREE_ARRAY(tokens);
     return SUCCESS_RETURN_CODE;
@@ -711,7 +701,6 @@ int test_parser_if_statement_with_else_branch() {
     PrintStatement* falsePrintStmt = falseBlock->statementArray.values[0]->as.printStatement;
     ASSERT(strcmp(falsePrintStmt->expression->as.primaryExpression->literal->as.stringLiteral->token.start, "\"Goodbye, World!\"") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     FREE_ARRAY(tokens);
     return SUCCESS_RETURN_CODE;
@@ -750,7 +739,6 @@ int test_parser_block_expression_simple() {
     ASSERT(blockExpr->lastExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(blockExpr->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -799,7 +787,6 @@ int test_parser_block_expression_nested() {
     ASSERT(innerBlockExpr->lastExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(innerBlockExpr->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -844,7 +831,6 @@ int test_parser_block_expression_with_statements() {
     ASSERT(blockExpr->lastExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(blockExpr->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -908,7 +894,6 @@ int test_parser_block_expression_as_if_condition() {
     ASSERT(trueBlock->statementArray.used == 1);
     ASSERT(trueBlock->statementArray.values[0]->type == PRINT_STATEMENT);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -936,7 +921,6 @@ int test_parser_var_declaration() {
     ASSERT(strcmp(varDecl->identifier->token.start, "a") == 0);
     ASSERT(varDecl->maybeExpression == NULL);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -969,7 +953,6 @@ int test_parser_var_declaration_with_initializer() {
     ASSERT(varDecl->maybeExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(varDecl->maybeExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "42") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1003,7 +986,6 @@ int test_parser_assignment() {
     ASSERT(assignmentStmt->value->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(assignmentStmt->value->as.primaryExpression->literal->as.numberLiteral->token.start, "2") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1035,7 +1017,6 @@ int test_parser_iteration_statement_no_curlys() {
     ASSERT(iterStmt->conditionExpression->type == PRIMARY_EXPRESSION);
     ASSERT(iterStmt->bodyStatement->type == PRINT_STATEMENT);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1065,7 +1046,6 @@ int test_parser_iteration_statement_no_parentheses_no_curlys() {
     ASSERT(iterStmt->conditionExpression->type == PRIMARY_EXPRESSION);
     ASSERT(iterStmt->bodyStatement->type == PRINT_STATEMENT);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1104,7 +1084,6 @@ int test_parser_iteration_statement_with_block() {
     ASSERT(iterStmt->bodyStatement->type == BLOCK_STATEMENT);
     ASSERT(iterStmt->bodyStatement->as.blockStatement->statementArray.used == 2);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1144,7 +1123,6 @@ int test_parser_lambda_expression_no_parameters() {
     ASSERT(lambdaExpr->bodyBlock->lastExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(lambdaExpr->bodyBlock->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "42") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1186,7 +1164,6 @@ int test_parser_lambda_expression_single_parameter() {
     ASSERT(lambdaExpr->bodyBlock->lastExpression->as.primaryExpression->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(lambdaExpr->bodyBlock->lastExpression->as.primaryExpression->literal->as.identifierLiteral->token.start, "x") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1231,7 +1208,6 @@ int test_parser_lambda_expression_multiple_parameters() {
     ASSERT(lambdaExpr->bodyBlock->statementArray.used == 0);
     ASSERT(lambdaExpr->bodyBlock->lastExpression->type == ADDITIVE_EXPRESSION);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1274,7 +1250,6 @@ int test_parser_lambda_expression_no_last_expression_in_block() {
 
     ASSERT(lambdaExpr->bodyBlock->lastExpression == NULL);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1341,7 +1316,6 @@ int test_parser_call_with_args() {
     ASSERT(strcmp(callBob->as.expressionStatement->expression->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "greet") == 0);
     ASSERT(callBob->as.expressionStatement->expression->as.callExpression->arguments->used == 1);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1398,7 +1372,6 @@ int test_parser_call_in_binary_expression() {
     ASSERT(addExpr->as.additiveExpression->rightExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(addExpr->as.additiveExpression->rightExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "10") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1441,7 +1414,6 @@ int test_parser_call_no_args() {
     ASSERT(strcmp(callExpr->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "myFunc") == 0);
     ASSERT(callExpr->as.callExpression->arguments->used == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1511,7 +1483,6 @@ int test_parser_recursive_call() {
     ASSERT(strcmp(recursiveCallExpr->as.multiplicativeExpression->rightExpression->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "factorial") == 0);
     ASSERT(recursiveCallExpr->as.multiplicativeExpression->rightExpression->as.callExpression->arguments->used == 1);
 
-    freeSource(source);
     freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -1578,7 +1549,6 @@ int test_parser_call_with_block_expression_arg() {
     ASSERT(callExpr->as.callExpression->arguments->used == 2);
     ASSERT(callExpr->as.callExpression->arguments->values[1]->type == LAMBDA_EXPRESSION);
 
-    freeSource(source);
     freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -1656,7 +1626,6 @@ int test_parser_nested_calls() {
     ASSERT(callAddTwo->as.callExpression->arguments->values[0]->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(callAddTwo->as.callExpression->arguments->values[0]->as.primaryExpression->literal->as.numberLiteral->token.start, "5") == 0);
 
-    freeSource(source);
     freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -1742,7 +1711,6 @@ int test_parser_call_with_expression_args() {
     ASSERT(secondArg->as.additiveExpression->rightExpression->type == PRIMARY_EXPRESSION);
     ASSERT(strcmp(secondArg->as.additiveExpression->rightExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
 
-    freeSource(source);
     freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -1811,7 +1779,6 @@ int test_parser_call_in_if_condition() {
     ASSERT(conditionExpr->as.callExpression->arguments->values[0]->type == PRIMARY_EXPRESSION);
     ASSERT(strcmp(conditionExpr->as.callExpression->arguments->values[0]->as.primaryExpression->literal->as.identifierLiteral->token.start, "num") == 0);
 
-    freeSource(source);
     freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -1869,7 +1836,6 @@ int test_parser_chained_calls() {
     ASSERT(primary->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(primary->literal->as.identifierLiteral->token.start, "add") == 0);
 
-    freeSource(source);
     freeParser(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -1898,7 +1864,6 @@ int test_parser_simple_return() {
     ASSERT(returnStmt->expression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(returnStmt->expression->as.primaryExpression->literal->as.numberLiteral->token.start, "42") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1923,7 +1888,6 @@ int test_parser_return_without_expression() {
     ReturnStatement* returnStmt = statement->as.returnStatement;
     ASSERT(returnStmt->expression == NULL);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1967,7 +1931,6 @@ int test_parser_return_in_lambda() {
     ASSERT(returnStmt->expression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(returnStmt->expression->as.primaryExpression->literal->as.numberLiteral->token.start, "10") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2035,7 +1998,6 @@ int test_parser_multiple_returns() {
     ASSERT(falseBlock->statementArray.used == 1);
     ASSERT(falseBlock->statementArray.values[0]->type == RETURN_STATEMENT);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2068,7 +2030,6 @@ int test_parser_member_expression_simple() {
     ASSERT(expr->as.memberExpression->rightHandSide->as.primaryExpression->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(expr->as.memberExpression->rightHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "b") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2105,7 +2066,6 @@ int test_parser_member_and_call_expression() {
     ASSERT(strcmp(expr->as.callExpression->leftHandSide->as.memberExpression->rightHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "b") == 0);
     ASSERT(expr->as.callExpression->arguments->used == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2147,7 +2107,6 @@ int test_parser_complex_member_and_call_expression() {
     ASSERT(expr->as.memberExpression->rightHandSide->as.primaryExpression->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(expr->as.memberExpression->rightHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "c") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2183,7 +2142,6 @@ int test_parser_nested_call_expression() {
     ASSERT(expr->as.callExpression->leftHandSide->as.callExpression->leftHandSide->as.callExpression->leftHandSide->as.primaryExpression->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(expr->as.callExpression->leftHandSide->as.callExpression->leftHandSide->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "a") == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2209,7 +2167,6 @@ int test_parser_empty_struct() {
     ASSERT(stmt->as.expressionStatement->expression->type == STRUCT_EXPRESSION);
     ASSERT(stmt->as.expressionStatement->expression->as.structExpression->declarationArray.used == 0);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2244,7 +2201,6 @@ int test_parser_struct_with_single_declaration() {
     ASSERT(structExpr->declarationArray.values[0]->maybeExpression->type == PRIMARY_EXPRESSION);
     ASSERT(structExpr->declarationArray.values[0]->maybeExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2299,7 +2255,6 @@ int test_parser_struct_with_multiple_declarations() {
     ASSERT(strcmp(structExpr->declarationArray.values[2]->identifier->token.start, "BaseStruct") == 0);
     ASSERT(structExpr->declarationArray.values[2]->maybeExpression == NULL);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2347,7 +2302,6 @@ int test_parser_struct_with_nested_struct() {
     ASSERT(innerStruct->declarationArray.values[0]->maybeExpression->type == PRIMARY_EXPRESSION);
     ASSERT(innerStruct->declarationArray.values[0]->maybeExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
 
-    freeSource(source);
     freeParser(&parser);
     return SUCCESS_RETURN_CODE;
 }

--- a/test/unit/src/parser_test.c
+++ b/test/unit/src/parser_test.c
@@ -94,7 +94,7 @@ int test_parser_simple_expression() {
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "2") == 0);
 
     // Clean up
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -110,7 +110,7 @@ int test_parser_print_statement() {
 
     FREE_ARRAY(tokens);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -152,7 +152,7 @@ int test_parser_logical_or_expression() {
     ASSERT(rightPrimary->literal->type == BOOLEAN_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.booleanLiteral->token.start, "false") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -192,7 +192,7 @@ int test_parser_logical_and_expression() {
     ASSERT(rightPrimary->literal->type == BOOLEAN_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.booleanLiteral->token.start, "true") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -232,7 +232,7 @@ int test_parser_equality_expression() {
     ASSERT(rightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "5") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -271,7 +271,7 @@ int test_parser_comparison_expression() {
     ASSERT(rightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "5") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -310,7 +310,7 @@ int test_parser_multiplicative_expression() {
     ASSERT(rightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "2") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -343,7 +343,7 @@ int test_parser_unary_expression() {
     ASSERT(rightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "1") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -372,7 +372,7 @@ int test_parser_boolean_literal() {
     ASSERT(primaryExpr->literal->type == BOOLEAN_LITERAL);
     ASSERT(strcmp(primaryExpr->literal->as.booleanLiteral->token.start, "true") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -471,7 +471,7 @@ int test_parser_complex_expression() {
     ASSERT(subRightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(subRightPrimary->literal->as.numberLiteral->token.start, "2") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -517,7 +517,7 @@ int test_parser_nested_parentheses_expression() {
 
     // Cleanup
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -566,7 +566,7 @@ int test_parser_variable_declaration_and_reading() {
 
     // Cleanup
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     FREE_ARRAY(tokens);
 
     return SUCCESS_RETURN_CODE;
@@ -600,7 +600,7 @@ int test_parser_string_literal() {
 
     // Cleanup
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     FREE_ARRAY(tokens);
 
     return SUCCESS_RETURN_CODE;
@@ -642,7 +642,7 @@ int test_parser_block_statement() {
 
     // Cleanup
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     FREE_ARRAY(tokens);
     return SUCCESS_RETURN_CODE;
 }
@@ -670,7 +670,7 @@ int test_parser_if_statement_true_branch_only() {
     ASSERT(printStmt->expression->as.primaryExpression->literal->type == STRING_LITERAL);
     ASSERT(strcmp(printStmt->expression->as.primaryExpression->literal->as.stringLiteral->token.start, "\"Hello, World!\"") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     FREE_ARRAY(tokens);
     return SUCCESS_RETURN_CODE;
 }
@@ -701,7 +701,7 @@ int test_parser_if_statement_with_else_branch() {
     PrintStatement* falsePrintStmt = falseBlock->statementArray.values[0]->as.printStatement;
     ASSERT(strcmp(falsePrintStmt->expression->as.primaryExpression->literal->as.stringLiteral->token.start, "\"Goodbye, World!\"") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     FREE_ARRAY(tokens);
     return SUCCESS_RETURN_CODE;
 }
@@ -739,7 +739,7 @@ int test_parser_block_expression_simple() {
     ASSERT(blockExpr->lastExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(blockExpr->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -787,7 +787,7 @@ int test_parser_block_expression_nested() {
     ASSERT(innerBlockExpr->lastExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(innerBlockExpr->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -831,7 +831,7 @@ int test_parser_block_expression_with_statements() {
     ASSERT(blockExpr->lastExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(blockExpr->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -894,7 +894,7 @@ int test_parser_block_expression_as_if_condition() {
     ASSERT(trueBlock->statementArray.used == 1);
     ASSERT(trueBlock->statementArray.values[0]->type == PRINT_STATEMENT);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -921,7 +921,7 @@ int test_parser_var_declaration() {
     ASSERT(strcmp(varDecl->identifier->token.start, "a") == 0);
     ASSERT(varDecl->maybeExpression == NULL);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -953,7 +953,7 @@ int test_parser_var_declaration_with_initializer() {
     ASSERT(varDecl->maybeExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(varDecl->maybeExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "42") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -986,7 +986,7 @@ int test_parser_assignment() {
     ASSERT(assignmentStmt->value->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(assignmentStmt->value->as.primaryExpression->literal->as.numberLiteral->token.start, "2") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1017,7 +1017,7 @@ int test_parser_iteration_statement_no_curlys() {
     ASSERT(iterStmt->conditionExpression->type == PRIMARY_EXPRESSION);
     ASSERT(iterStmt->bodyStatement->type == PRINT_STATEMENT);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1046,7 +1046,7 @@ int test_parser_iteration_statement_no_parentheses_no_curlys() {
     ASSERT(iterStmt->conditionExpression->type == PRIMARY_EXPRESSION);
     ASSERT(iterStmt->bodyStatement->type == PRINT_STATEMENT);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1084,7 +1084,7 @@ int test_parser_iteration_statement_with_block() {
     ASSERT(iterStmt->bodyStatement->type == BLOCK_STATEMENT);
     ASSERT(iterStmt->bodyStatement->as.blockStatement->statementArray.used == 2);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1123,7 +1123,7 @@ int test_parser_lambda_expression_no_parameters() {
     ASSERT(lambdaExpr->bodyBlock->lastExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(lambdaExpr->bodyBlock->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "42") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1164,7 +1164,7 @@ int test_parser_lambda_expression_single_parameter() {
     ASSERT(lambdaExpr->bodyBlock->lastExpression->as.primaryExpression->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(lambdaExpr->bodyBlock->lastExpression->as.primaryExpression->literal->as.identifierLiteral->token.start, "x") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1208,7 +1208,7 @@ int test_parser_lambda_expression_multiple_parameters() {
     ASSERT(lambdaExpr->bodyBlock->statementArray.used == 0);
     ASSERT(lambdaExpr->bodyBlock->lastExpression->type == ADDITIVE_EXPRESSION);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1250,7 +1250,7 @@ int test_parser_lambda_expression_no_last_expression_in_block() {
 
     ASSERT(lambdaExpr->bodyBlock->lastExpression == NULL);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1316,7 +1316,7 @@ int test_parser_call_with_args() {
     ASSERT(strcmp(callBob->as.expressionStatement->expression->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "greet") == 0);
     ASSERT(callBob->as.expressionStatement->expression->as.callExpression->arguments->used == 1);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1372,7 +1372,7 @@ int test_parser_call_in_binary_expression() {
     ASSERT(addExpr->as.additiveExpression->rightExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(addExpr->as.additiveExpression->rightExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "10") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1414,7 +1414,7 @@ int test_parser_call_no_args() {
     ASSERT(strcmp(callExpr->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "myFunc") == 0);
     ASSERT(callExpr->as.callExpression->arguments->used == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1483,7 +1483,7 @@ int test_parser_recursive_call() {
     ASSERT(strcmp(recursiveCallExpr->as.multiplicativeExpression->rightExpression->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "factorial") == 0);
     ASSERT(recursiveCallExpr->as.multiplicativeExpression->rightExpression->as.callExpression->arguments->used == 1);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -1549,7 +1549,7 @@ int test_parser_call_with_block_expression_arg() {
     ASSERT(callExpr->as.callExpression->arguments->used == 2);
     ASSERT(callExpr->as.callExpression->arguments->values[1]->type == LAMBDA_EXPRESSION);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -1626,7 +1626,7 @@ int test_parser_nested_calls() {
     ASSERT(callAddTwo->as.callExpression->arguments->values[0]->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(callAddTwo->as.callExpression->arguments->values[0]->as.primaryExpression->literal->as.numberLiteral->token.start, "5") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -1711,7 +1711,7 @@ int test_parser_call_with_expression_args() {
     ASSERT(secondArg->as.additiveExpression->rightExpression->type == PRIMARY_EXPRESSION);
     ASSERT(strcmp(secondArg->as.additiveExpression->rightExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -1779,7 +1779,7 @@ int test_parser_call_in_if_condition() {
     ASSERT(conditionExpr->as.callExpression->arguments->values[0]->type == PRIMARY_EXPRESSION);
     ASSERT(strcmp(conditionExpr->as.callExpression->arguments->values[0]->as.primaryExpression->literal->as.identifierLiteral->token.start, "num") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -1836,7 +1836,7 @@ int test_parser_chained_calls() {
     ASSERT(primary->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(primary->literal->as.identifierLiteral->token.start, "add") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -1864,7 +1864,7 @@ int test_parser_simple_return() {
     ASSERT(returnStmt->expression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(returnStmt->expression->as.primaryExpression->literal->as.numberLiteral->token.start, "42") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1888,7 +1888,7 @@ int test_parser_return_without_expression() {
     ReturnStatement* returnStmt = statement->as.returnStatement;
     ASSERT(returnStmt->expression == NULL);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1931,7 +1931,7 @@ int test_parser_return_in_lambda() {
     ASSERT(returnStmt->expression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(returnStmt->expression->as.primaryExpression->literal->as.numberLiteral->token.start, "10") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1998,7 +1998,7 @@ int test_parser_multiple_returns() {
     ASSERT(falseBlock->statementArray.used == 1);
     ASSERT(falseBlock->statementArray.values[0]->type == RETURN_STATEMENT);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -2030,7 +2030,7 @@ int test_parser_member_expression_simple() {
     ASSERT(expr->as.memberExpression->rightHandSide->as.primaryExpression->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(expr->as.memberExpression->rightHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "b") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -2066,7 +2066,7 @@ int test_parser_member_and_call_expression() {
     ASSERT(strcmp(expr->as.callExpression->leftHandSide->as.memberExpression->rightHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "b") == 0);
     ASSERT(expr->as.callExpression->arguments->used == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -2107,7 +2107,7 @@ int test_parser_complex_member_and_call_expression() {
     ASSERT(expr->as.memberExpression->rightHandSide->as.primaryExpression->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(expr->as.memberExpression->rightHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "c") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -2142,7 +2142,7 @@ int test_parser_nested_call_expression() {
     ASSERT(expr->as.callExpression->leftHandSide->as.callExpression->leftHandSide->as.callExpression->leftHandSide->as.primaryExpression->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(expr->as.callExpression->leftHandSide->as.callExpression->leftHandSide->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "a") == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -2167,7 +2167,7 @@ int test_parser_empty_struct() {
     ASSERT(stmt->as.expressionStatement->expression->type == STRUCT_EXPRESSION);
     ASSERT(stmt->as.expressionStatement->expression->as.structExpression->declarationArray.used == 0);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -2201,7 +2201,7 @@ int test_parser_struct_with_single_declaration() {
     ASSERT(structExpr->declarationArray.values[0]->maybeExpression->type == PRIMARY_EXPRESSION);
     ASSERT(structExpr->declarationArray.values[0]->maybeExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -2255,7 +2255,7 @@ int test_parser_struct_with_multiple_declarations() {
     ASSERT(strcmp(structExpr->declarationArray.values[2]->identifier->token.start, "BaseStruct") == 0);
     ASSERT(structExpr->declarationArray.values[2]->maybeExpression == NULL);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -2302,6 +2302,6 @@ int test_parser_struct_with_nested_struct() {
     ASSERT(innerStruct->declarationArray.values[0]->maybeExpression->type == PRIMARY_EXPRESSION);
     ASSERT(innerStruct->declarationArray.values[0]->maybeExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
 
-    freeParser(&parser);
+    freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }

--- a/test/unit/src/parser_test.c
+++ b/test/unit/src/parser_test.c
@@ -94,6 +94,7 @@ int test_parser_simple_expression() {
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "2") == 0);
 
     // Clean up
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -109,7 +110,7 @@ int test_parser_print_statement() {
     ASSERT(source->rootStatements[0]->as.printStatement->expression->type == ADDITIVE_EXPRESSION);
 
     FREE_ARRAY(tokens);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -151,7 +152,7 @@ int test_parser_logical_or_expression() {
     PrimaryExpression* rightPrimary = orExpr->rightExpression->as.primaryExpression;
     ASSERT(rightPrimary->literal->type == BOOLEAN_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.booleanLiteral->token.start, "false") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -191,7 +192,7 @@ int test_parser_logical_and_expression() {
     PrimaryExpression* rightPrimary = andExpr->rightExpression->as.primaryExpression;
     ASSERT(rightPrimary->literal->type == BOOLEAN_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.booleanLiteral->token.start, "true") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -231,7 +232,7 @@ int test_parser_equality_expression() {
     PrimaryExpression* rightPrimary = eqExpr->rightExpression->as.primaryExpression;
     ASSERT(rightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "5") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -270,7 +271,7 @@ int test_parser_comparison_expression() {
     PrimaryExpression* rightPrimary = compExpr->rightExpression->as.primaryExpression;
     ASSERT(rightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "5") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -309,7 +310,7 @@ int test_parser_multiplicative_expression() {
     PrimaryExpression* rightPrimary = multExpr->rightExpression->as.primaryExpression;
     ASSERT(rightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "2") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -342,7 +343,7 @@ int test_parser_unary_expression() {
     PrimaryExpression* rightPrimary = unaryExpr->rightExpression->as.primaryExpression;
     ASSERT(rightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(rightPrimary->literal->as.numberLiteral->token.start, "1") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -371,7 +372,7 @@ int test_parser_boolean_literal() {
     PrimaryExpression* primaryExpr = expression->as.primaryExpression;
     ASSERT(primaryExpr->literal->type == BOOLEAN_LITERAL);
     ASSERT(strcmp(primaryExpr->literal->as.booleanLiteral->token.start, "true") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -470,7 +471,7 @@ int test_parser_complex_expression() {
     PrimaryExpression* subRightPrimary = subtractionExpr->rightExpression->as.primaryExpression;
     ASSERT(subRightPrimary->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(subRightPrimary->literal->as.numberLiteral->token.start, "2") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -516,7 +517,7 @@ int test_parser_nested_parentheses_expression() {
     ASSERT(rightExpression->type == MULTIPLICATIVE_EXPRESSION);  // The nested expression should be multiplication
 
     // Cleanup
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -565,7 +566,7 @@ int test_parser_variable_declaration_and_reading() {
     ASSERT(strncmp(printIdLiteral->token.start, "x", printIdLiteral->token.length) == 0);
 
     // Cleanup
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     FREE_ARRAY(tokens);
 
@@ -599,7 +600,7 @@ int test_parser_string_literal() {
     ASSERT(strcmp(primaryExpression->literal->as.stringLiteral->token.start, "\"Hello, World!\"") == 0);
 
     // Cleanup
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     FREE_ARRAY(tokens);
 
@@ -641,7 +642,7 @@ int test_parser_block_statement() {
     ASSERT(printStmt->expression->type == PRIMARY_EXPRESSION);
 
     // Cleanup
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     FREE_ARRAY(tokens);
     return SUCCESS_RETURN_CODE;
@@ -669,7 +670,7 @@ int test_parser_if_statement_true_branch_only() {
     ASSERT(printStmt->expression->type == PRIMARY_EXPRESSION);
     ASSERT(printStmt->expression->as.primaryExpression->literal->type == STRING_LITERAL);
     ASSERT(strcmp(printStmt->expression->as.primaryExpression->literal->as.stringLiteral->token.start, "\"Hello, World!\"") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     FREE_ARRAY(tokens);
     return SUCCESS_RETURN_CODE;
@@ -700,7 +701,7 @@ int test_parser_if_statement_with_else_branch() {
     ASSERT(falseBlock->statementArray.used == 1);
     PrintStatement* falsePrintStmt = falseBlock->statementArray.values[0]->as.printStatement;
     ASSERT(strcmp(falsePrintStmt->expression->as.primaryExpression->literal->as.stringLiteral->token.start, "\"Goodbye, World!\"") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     FREE_ARRAY(tokens);
     return SUCCESS_RETURN_CODE;
@@ -738,7 +739,7 @@ int test_parser_block_expression_simple() {
 
     ASSERT(blockExpr->lastExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(blockExpr->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -786,7 +787,7 @@ int test_parser_block_expression_nested() {
 
     ASSERT(innerBlockExpr->lastExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(innerBlockExpr->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -830,7 +831,7 @@ int test_parser_block_expression_with_statements() {
     ASSERT(blockExpr->lastExpression->type == PRIMARY_EXPRESSION);
     ASSERT(blockExpr->lastExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(blockExpr->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -893,7 +894,7 @@ int test_parser_block_expression_as_if_condition() {
     BlockStatement* trueBlock = selectionStmt->trueStatement->as.blockStatement;
     ASSERT(trueBlock->statementArray.used == 1);
     ASSERT(trueBlock->statementArray.values[0]->type == PRINT_STATEMENT);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -920,7 +921,7 @@ int test_parser_var_declaration() {
     VarDeclarationStatement* varDecl = statement->as.varDeclarationStatement;
     ASSERT(strcmp(varDecl->identifier->token.start, "a") == 0);
     ASSERT(varDecl->maybeExpression == NULL);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -952,7 +953,7 @@ int test_parser_var_declaration_with_initializer() {
     ASSERT(varDecl->maybeExpression->type == PRIMARY_EXPRESSION);
     ASSERT(varDecl->maybeExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(varDecl->maybeExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "42") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -985,7 +986,7 @@ int test_parser_assignment() {
     ASSERT(assignmentStmt->value->type == PRIMARY_EXPRESSION);
     ASSERT(assignmentStmt->value->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(assignmentStmt->value->as.primaryExpression->literal->as.numberLiteral->token.start, "2") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1016,7 +1017,7 @@ int test_parser_iteration_statement_no_curlys() {
     IterationStatement* iterStmt = iterationStmt->as.iterationStatement;
     ASSERT(iterStmt->conditionExpression->type == PRIMARY_EXPRESSION);
     ASSERT(iterStmt->bodyStatement->type == PRINT_STATEMENT);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1045,7 +1046,7 @@ int test_parser_iteration_statement_no_parentheses_no_curlys() {
     IterationStatement* iterStmt = iterationStmt->as.iterationStatement;
     ASSERT(iterStmt->conditionExpression->type == PRIMARY_EXPRESSION);
     ASSERT(iterStmt->bodyStatement->type == PRINT_STATEMENT);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1083,7 +1084,7 @@ int test_parser_iteration_statement_with_block() {
     ASSERT(iterStmt->conditionExpression->type == PRIMARY_EXPRESSION);
     ASSERT(iterStmt->bodyStatement->type == BLOCK_STATEMENT);
     ASSERT(iterStmt->bodyStatement->as.blockStatement->statementArray.used == 2);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1122,7 +1123,7 @@ int test_parser_lambda_expression_no_parameters() {
     ASSERT(lambdaExpr->bodyBlock->lastExpression->type == PRIMARY_EXPRESSION);
     ASSERT(lambdaExpr->bodyBlock->lastExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(lambdaExpr->bodyBlock->lastExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "42") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1163,7 +1164,7 @@ int test_parser_lambda_expression_single_parameter() {
     ASSERT(lambdaExpr->bodyBlock->lastExpression->type == PRIMARY_EXPRESSION);
     ASSERT(lambdaExpr->bodyBlock->lastExpression->as.primaryExpression->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(lambdaExpr->bodyBlock->lastExpression->as.primaryExpression->literal->as.identifierLiteral->token.start, "x") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1207,7 +1208,7 @@ int test_parser_lambda_expression_multiple_parameters() {
 
     ASSERT(lambdaExpr->bodyBlock->statementArray.used == 0);
     ASSERT(lambdaExpr->bodyBlock->lastExpression->type == ADDITIVE_EXPRESSION);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1249,7 +1250,7 @@ int test_parser_lambda_expression_no_last_expression_in_block() {
     ASSERT(lambdaExpr->bodyBlock->statementArray.values[0]->as.printStatement->expression->as.primaryExpression->literal->type == STRING_LITERAL);
 
     ASSERT(lambdaExpr->bodyBlock->lastExpression == NULL);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1315,7 +1316,7 @@ int test_parser_call_with_args() {
     ASSERT(callBob->as.expressionStatement->expression->type == CALL_EXPRESSION);
     ASSERT(strcmp(callBob->as.expressionStatement->expression->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "greet") == 0);
     ASSERT(callBob->as.expressionStatement->expression->as.callExpression->arguments->used == 1);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1371,7 +1372,7 @@ int test_parser_call_in_binary_expression() {
     ASSERT(addExpr->as.additiveExpression->rightExpression->type == PRIMARY_EXPRESSION);
     ASSERT(addExpr->as.additiveExpression->rightExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(addExpr->as.additiveExpression->rightExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "10") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1413,7 +1414,7 @@ int test_parser_call_no_args() {
     ASSERT(callExpr->type == CALL_EXPRESSION);
     ASSERT(strcmp(callExpr->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "myFunc") == 0);
     ASSERT(callExpr->as.callExpression->arguments->used == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1482,7 +1483,7 @@ int test_parser_recursive_call() {
     ASSERT(recursiveCallExpr->as.multiplicativeExpression->rightExpression->type == CALL_EXPRESSION);
     ASSERT(strcmp(recursiveCallExpr->as.multiplicativeExpression->rightExpression->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "factorial") == 0);
     ASSERT(recursiveCallExpr->as.multiplicativeExpression->rightExpression->as.callExpression->arguments->used == 1);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -1548,7 +1549,7 @@ int test_parser_call_with_block_expression_arg() {
     ASSERT(strcmp(callExpr->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "applyOperation") == 0);
     ASSERT(callExpr->as.callExpression->arguments->used == 2);
     ASSERT(callExpr->as.callExpression->arguments->values[1]->type == LAMBDA_EXPRESSION);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -1625,7 +1626,7 @@ int test_parser_nested_calls() {
     ASSERT(callAddTwo->as.callExpression->arguments->values[0]->type == PRIMARY_EXPRESSION);
     ASSERT(callAddTwo->as.callExpression->arguments->values[0]->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(callAddTwo->as.callExpression->arguments->values[0]->as.primaryExpression->literal->as.numberLiteral->token.start, "5") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -1710,7 +1711,7 @@ int test_parser_call_with_expression_args() {
     ASSERT(strcmp(secondArg->as.additiveExpression->leftExpression->as.primaryExpression->literal->as.identifierLiteral->token.start, "y") == 0);
     ASSERT(secondArg->as.additiveExpression->rightExpression->type == PRIMARY_EXPRESSION);
     ASSERT(strcmp(secondArg->as.additiveExpression->rightExpression->as.primaryExpression->literal->as.numberLiteral->token.start, "3") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -1778,7 +1779,7 @@ int test_parser_call_in_if_condition() {
     ASSERT(conditionExpr->as.callExpression->arguments->used == 1);
     ASSERT(conditionExpr->as.callExpression->arguments->values[0]->type == PRIMARY_EXPRESSION);
     ASSERT(strcmp(conditionExpr->as.callExpression->arguments->values[0]->as.primaryExpression->literal->as.identifierLiteral->token.start, "num") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -1835,7 +1836,7 @@ int test_parser_chained_calls() {
     PrimaryExpression* primary = call3->leftHandSide->as.primaryExpression;
     ASSERT(primary->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(primary->literal->as.identifierLiteral->token.start, "add") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
 
     return SUCCESS_RETURN_CODE;
@@ -1863,7 +1864,7 @@ int test_parser_simple_return() {
     ASSERT(returnStmt->expression->type == PRIMARY_EXPRESSION);
     ASSERT(returnStmt->expression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(returnStmt->expression->as.primaryExpression->literal->as.numberLiteral->token.start, "42") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1887,7 +1888,7 @@ int test_parser_return_without_expression() {
     ASSERT(statement->type == RETURN_STATEMENT);
     ReturnStatement* returnStmt = statement->as.returnStatement;
     ASSERT(returnStmt->expression == NULL);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1930,7 +1931,7 @@ int test_parser_return_in_lambda() {
     ASSERT(returnStmt->expression->type == PRIMARY_EXPRESSION);
     ASSERT(returnStmt->expression->as.primaryExpression->literal->type == NUMBER_LITERAL);
     ASSERT(strcmp(returnStmt->expression->as.primaryExpression->literal->as.numberLiteral->token.start, "10") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -1997,7 +1998,7 @@ int test_parser_multiple_returns() {
     BlockStatement* falseBlock = selection->falseStatement->as.blockStatement;
     ASSERT(falseBlock->statementArray.used == 1);
     ASSERT(falseBlock->statementArray.values[0]->type == RETURN_STATEMENT);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2029,7 +2030,7 @@ int test_parser_member_expression_simple() {
     ASSERT(expr->as.memberExpression->rightHandSide->type == PRIMARY_EXPRESSION);
     ASSERT(expr->as.memberExpression->rightHandSide->as.primaryExpression->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(expr->as.memberExpression->rightHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "b") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2065,7 +2066,7 @@ int test_parser_member_and_call_expression() {
     ASSERT(expr->as.callExpression->leftHandSide->as.memberExpression->rightHandSide->as.primaryExpression->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(expr->as.callExpression->leftHandSide->as.memberExpression->rightHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "b") == 0);
     ASSERT(expr->as.callExpression->arguments->used == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2106,7 +2107,7 @@ int test_parser_complex_member_and_call_expression() {
     ASSERT(expr->as.memberExpression->rightHandSide->type == PRIMARY_EXPRESSION);
     ASSERT(expr->as.memberExpression->rightHandSide->as.primaryExpression->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(expr->as.memberExpression->rightHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "c") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2141,7 +2142,7 @@ int test_parser_nested_call_expression() {
     ASSERT(expr->as.callExpression->leftHandSide->as.callExpression->leftHandSide->as.callExpression->leftHandSide->type == PRIMARY_EXPRESSION);
     ASSERT(expr->as.callExpression->leftHandSide->as.callExpression->leftHandSide->as.callExpression->leftHandSide->as.primaryExpression->literal->type == IDENTIFIER_LITERAL);
     ASSERT(strcmp(expr->as.callExpression->leftHandSide->as.callExpression->leftHandSide->as.callExpression->leftHandSide->as.primaryExpression->literal->as.identifierLiteral->token.start, "a") == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2166,7 +2167,7 @@ int test_parser_empty_struct() {
     ASSERT(stmt->type == EXPRESSION_STATEMENT);
     ASSERT(stmt->as.expressionStatement->expression->type == STRUCT_EXPRESSION);
     ASSERT(stmt->as.expressionStatement->expression->as.structExpression->declarationArray.used == 0);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2200,7 +2201,7 @@ int test_parser_struct_with_single_declaration() {
     ASSERT(strcmp(structExpr->declarationArray.values[0]->identifier->token.start, "x") == 0);
     ASSERT(structExpr->declarationArray.values[0]->maybeExpression->type == PRIMARY_EXPRESSION);
     ASSERT(structExpr->declarationArray.values[0]->maybeExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2254,7 +2255,7 @@ int test_parser_struct_with_multiple_declarations() {
     ASSERT(structExpr->declarationArray.values[2]->isPrototype);
     ASSERT(strcmp(structExpr->declarationArray.values[2]->identifier->token.start, "BaseStruct") == 0);
     ASSERT(structExpr->declarationArray.values[2]->maybeExpression == NULL);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }
@@ -2301,7 +2302,7 @@ int test_parser_struct_with_nested_struct() {
     ASSERT(strcmp(innerStruct->declarationArray.values[0]->identifier->token.start, "inner") == 0);
     ASSERT(innerStruct->declarationArray.values[0]->maybeExpression->type == PRIMARY_EXPRESSION);
     ASSERT(innerStruct->declarationArray.values[0]->maybeExpression->as.primaryExpression->literal->type == NUMBER_LITERAL);
-
+    freeSource(parser.source);
     freeParserButNotAST(&parser);
     return SUCCESS_RETURN_CODE;
 }

--- a/test/unit/src/scanner_test.c
+++ b/test/unit/src/scanner_test.c
@@ -24,5 +24,8 @@ int test_scanner() {
                             printf("ERROR - %s is not equal to %s.\n", tokenTypeToString(actualToken), tokenTypeToString(expectedToken)));
     }
 
+    free(sourceCode);
+    FREE_ARRAY(tokens);
+
     return SUCCESS_RETURN_CODE;
 }

--- a/test/unit/src/vm_test.c
+++ b/test/unit/src/vm_test.c
@@ -40,8 +40,8 @@ CompiledCode newCompiledCode() {
     return compiledCode;
 }
 
-// Create new empty compiled code
-void freeCompiledCode(CompiledCode* compiledCode) {
+// Free compiled code. Used only in the context of these tests
+static void _freeCompiledCode(CompiledCode* compiledCode) {
     FREE_ARRAY(compiledCode->topLevelCodeObject.bytecodeArray);
     FREE_ARRAY(compiledCode->topLevelCodeObject.constantPool);
 }
@@ -103,8 +103,7 @@ int test_vm_addition() {
     ASSERT(compareValues(actual_result, expected_result));
 
     // Clean up
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -149,8 +148,7 @@ int test_vm_print() {
     ASSERT(strcmp(buffer, expectedOutput) == 0);
 
     // Clean up
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -183,8 +181,7 @@ int test_vm_set_and_get_global() {
     ASSERT(compareValues(actual_result, expected_result));
 
     // Clean up
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -215,8 +212,7 @@ int test_vm_binary_equal() {
     ASSERT(result_not_equal.type == TYPE_BOOLEAN && result_not_equal.as.booleanVal == false);
 
     // Clean up
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -264,8 +260,7 @@ int test_vm_comparison_operations() {
     ASSERT(result_gte.type == TYPE_BOOLEAN && result_gte.as.booleanVal == true);
 
     // Clean up
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -299,8 +294,7 @@ int test_vm_logical_operations() {
     ASSERT(result_or.type == TYPE_BOOLEAN && result_or.as.booleanVal == true);
 
     // Clean up
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -325,8 +319,7 @@ int test_vm_boolean_truthiness() {
     ASSERT(result.type == TYPE_BOOLEAN && result.as.booleanVal == false);
 
     // Clean up
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -353,8 +346,7 @@ int test_vm_unary_negation() {
     ASSERT(result.type == TYPE_DOUBLE && result.as.doubleVal == -5.0);
 
     // Clean up
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -389,8 +381,8 @@ int test_vm_unary_not() {
     ASSERT(resultFalse.type == TYPE_BOOLEAN && resultFalse.as.booleanVal == true);
 
     // Clean up
-    freeCompiledCode(&codeTrue);
-    freeCompiledCode(&codeFalse);
+    _freeCompiledCode(&codeTrue);
+    _freeCompiledCode(&codeFalse);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -413,8 +405,7 @@ int test_vm_print_string_literal() {
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "Hello, World!\n") == 0); });
 
     // Cleanup
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -443,8 +434,7 @@ int test_vm_simple_block_statement_and_cleanup() {
     ASSERT(vm.currFrame->SP == vm.stack);
 
     // Cleanup
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -517,8 +507,7 @@ int test_vm_nested_blocks_with_global_and_local_vars() {
         ASSERT(strcmp(buffer, expectedOutput) == 0); });
 
     // Clean up
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -564,8 +553,7 @@ int test_vm_nested_if_statements() {
         ASSERT(strcmp(buffer, "true-outer\nfalse-inner\n") == 0); });
 
     // Clean up
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;  // Assuming SUCCESS_RETURN_CODE is defined as part of your testing framework
 }
@@ -591,8 +579,7 @@ int test_vm_simple_block_expression() {
 
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "10.000000\n") == 0); });
 
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -623,8 +610,7 @@ int test_vm_block_expression_with_statements() {
 
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "8.000000\n") == 0); });
 
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -657,8 +643,7 @@ int test_vm_block_expression_as_if_condition() {
 
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "Passed\n") == 0); });
 
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -685,8 +670,7 @@ int test_vm_var_declaration_and_assignment_global() {
     initVM(&vm, compiledCode);
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "10.000000\n") == 0); });
 
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -715,8 +699,7 @@ int test_vm_var_declaration_and_assignment_local() {
     initVM(&vm, compiledCode);
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "10.000000\n") == 0); });
 
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -766,8 +749,7 @@ int test_vm_block_expression_with_val_declarations() {
     initVM(&vm, compiledCode);
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "3.000000\n12.000000\n") == 0); });
 
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -810,8 +792,7 @@ int test_vm_var_val_declarations_in_nested_blocks() {
     initVM(&vm, compiledCode);
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "1.000000\n2.000000\n1.000000\n") == 0); });
 
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -857,8 +838,7 @@ int test_vm_var_assignment_global_and_local() {
     initVM(&vm, compiledCode);
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "1.000000\n2.000000\n1.000000\n") == 0); });
 
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -893,8 +873,7 @@ int test_vm_global_declaration_and_local_assignment() {
     initVM(&vm, compiledCode);
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "1.000000\n1.000000\n") == 0); });
 
-    FREE_ARRAY(compiledCode.topLevelCodeObject.bytecodeArray);
-    FREE_ARRAY(compiledCode.topLevelCodeObject.constantPool);
+    _freeCompiledCode(&compiledCode);
 
     return SUCCESS_RETURN_CODE;
 }
@@ -1064,7 +1043,7 @@ int test_vm_lambda_no_params() {
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "42.000000\n") == 0); });
 
     freeVM(&vm);
-    freeCompiledCode(&code);
+    _freeCompiledCode(&code);
     freeLambdaFunction(lambda);
 
     return SUCCESS_RETURN_CODE;
@@ -1102,7 +1081,7 @@ int test_vm_lambda_one_param() {
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "5.000000\n") == 0); });
 
     freeVM(&vm);
-    freeCompiledCode(&code);
+    _freeCompiledCode(&code);
     freeLambdaFunction(lambda);
     return SUCCESS_RETURN_CODE;
 }
@@ -1143,7 +1122,7 @@ int test_vm_lambda_two_params() {
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "7.000000\n") == 0); });
 
     freeVM(&vm);
-    freeCompiledCode(&code);
+    _freeCompiledCode(&code);
     freeLambdaFunction(lambda);
     return SUCCESS_RETURN_CODE;
 }
@@ -1209,7 +1188,7 @@ int test_vm_lambda_nested_calls() {
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "26.000000\n") == 0); });
 
     freeVM(&vm);
-    freeCompiledCode(&code);
+    _freeCompiledCode(&code);
     freeLambdaFunction(multiplyLambda);
     freeLambdaFunction(addLambda);
     return SUCCESS_RETURN_CODE;
@@ -1245,7 +1224,7 @@ int test_vm_simple_struct() {
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "10.000000\nhello\n") == 0); });
 
     freeVM(&vm);
-    freeCompiledCode(&code);
+    _freeCompiledCode(&code);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1276,7 +1255,7 @@ int test_vm_nested_structs() {
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "42.000000\n") == 0); });
 
     freeVM(&vm);
-    freeCompiledCode(&code);
+    _freeCompiledCode(&code);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1309,7 +1288,7 @@ int test_vm_struct_field_assignment() {
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "10.000000\n20.000000\n") == 0); });
 
     freeVM(&vm);
-    freeCompiledCode(&code);
+    _freeCompiledCode(&code);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1356,7 +1335,7 @@ int test_vm_struct_in_function_call() {
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "42.000000\n") == 0); });
 
     freeVM(&vm);
-    freeCompiledCode(&code);
+    _freeCompiledCode(&code);
     freeLambdaFunction(getX);
     return SUCCESS_RETURN_CODE;
 }

--- a/test/unit/src/vm_test.c
+++ b/test/unit/src/vm_test.c
@@ -64,6 +64,13 @@ static Value popVmStack(VM* vm) {
     return *(vm->currFrame->SP);
 }
 
+void freeLambdaFunction(Function* function) {
+    FREE_ARRAY(function->code->bytecodeArray);
+    FREE_ARRAY(function->code->constantPool);
+    free(function->code);
+    free(function);
+}
+
 int test_vm_addition() {
     CompiledCode compiledCode = newCompiledCode();
 
@@ -1058,6 +1065,8 @@ int test_vm_lambda_no_params() {
 
     freeVM(&vm);
     freeCompiledCode(&code);
+    freeLambdaFunction(lambda);
+
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1094,6 +1103,7 @@ int test_vm_lambda_one_param() {
 
     freeVM(&vm);
     freeCompiledCode(&code);
+    freeLambdaFunction(lambda);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1134,6 +1144,7 @@ int test_vm_lambda_two_params() {
 
     freeVM(&vm);
     freeCompiledCode(&code);
+    freeLambdaFunction(lambda);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1199,6 +1210,8 @@ int test_vm_lambda_nested_calls() {
 
     freeVM(&vm);
     freeCompiledCode(&code);
+    freeLambdaFunction(multiplyLambda);
+    freeLambdaFunction(addLambda);
     return SUCCESS_RETURN_CODE;
 }
 
@@ -1344,5 +1357,6 @@ int test_vm_struct_in_function_call() {
 
     freeVM(&vm);
     freeCompiledCode(&code);
+    freeLambdaFunction(getX);
     return SUCCESS_RETURN_CODE;
 }

--- a/test/unit/src/vm_test.c
+++ b/test/unit/src/vm_test.c
@@ -1042,7 +1042,7 @@ int test_vm_lambda_no_params() {
 
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "42.000000\n") == 0); });
 
-    freeVM(&vm);
+    freeVMButNotCompiledCode(&vm);
     _freeCompiledCode(&code);
     freeLambdaFunction(lambda);
 
@@ -1080,7 +1080,7 @@ int test_vm_lambda_one_param() {
 
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "5.000000\n") == 0); });
 
-    freeVM(&vm);
+    freeVMButNotCompiledCode(&vm);
     _freeCompiledCode(&code);
     freeLambdaFunction(lambda);
     return SUCCESS_RETURN_CODE;
@@ -1121,7 +1121,7 @@ int test_vm_lambda_two_params() {
 
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "7.000000\n") == 0); });
 
-    freeVM(&vm);
+    freeVMButNotCompiledCode(&vm);
     _freeCompiledCode(&code);
     freeLambdaFunction(lambda);
     return SUCCESS_RETURN_CODE;
@@ -1187,7 +1187,7 @@ int test_vm_lambda_nested_calls() {
 
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "26.000000\n") == 0); });
 
-    freeVM(&vm);
+    freeVMButNotCompiledCode(&vm);
     _freeCompiledCode(&code);
     freeLambdaFunction(multiplyLambda);
     freeLambdaFunction(addLambda);
@@ -1223,7 +1223,7 @@ int test_vm_simple_struct() {
 
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "10.000000\nhello\n") == 0); });
 
-    freeVM(&vm);
+    freeVMButNotCompiledCode(&vm);
     _freeCompiledCode(&code);
     return SUCCESS_RETURN_CODE;
 }
@@ -1254,7 +1254,7 @@ int test_vm_nested_structs() {
 
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "42.000000\n") == 0); });
 
-    freeVM(&vm);
+    freeVMButNotCompiledCode(&vm);
     _freeCompiledCode(&code);
     return SUCCESS_RETURN_CODE;
 }
@@ -1287,7 +1287,7 @@ int test_vm_struct_field_assignment() {
 
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "10.000000\n20.000000\n") == 0); });
 
-    freeVM(&vm);
+    freeVMButNotCompiledCode(&vm);
     _freeCompiledCode(&code);
     return SUCCESS_RETURN_CODE;
 }
@@ -1334,7 +1334,7 @@ int test_vm_struct_in_function_call() {
 
     CAPTURE_PRINT_OUTPUT({ run(&vm); }, { ASSERT(strcmp(buffer, "42.000000\n") == 0); });
 
-    freeVM(&vm);
+    freeVMButNotCompiledCode(&vm);
     _freeCompiledCode(&code);
     freeLambdaFunction(getX);
     return SUCCESS_RETURN_CODE;


### PR DESCRIPTION
### Summary
Fix some memory leaks present in the code. Such as:
* Incomplete AST freeing
* Incomplete compiled code freeing
* No freeing in tests (e.g. in the e2e tests)
* Incomplete freeing in main.c and REPL

This does NOT address runtime memory leaks. We need a garbage collector for that.

### Testing

Existing unit and integration tests pass.

Manually ran REPL and things still work.

Manually executed code file (`code.sol`) and it still works.